### PR TITLE
Use PtGen archive providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ dft [插件名字] -f [种子文件夹] -u [豆瓣URL]
 - `config`: 配置文件的位置，默认读取当前文件夹下的`config.ini`
 - `log`: log文件的路径
 - `folder`: 种子文件或文件夹的路径
-- `url`: 影片的豆瓣链接，事实上，所有PTGen支持的链接这里都支持
+- `url`: 影片的豆瓣链接，事实上，所有PtGen Archive支持的链接这里都支持，差速器会自动通过Ourhelp CDN、GitHub Pages和Ourhelp API provider获取并生成介绍内容
 - `upload_url`: 发种页面的地址
 - `make_torrent`: 是否制种，默认关闭
 - `geenrate_nfo`: 是否利用mediainfo生成nfo文件，默认关闭
@@ -84,7 +84,6 @@ dft [插件名字] -f [种子文件夹] -u [豆瓣URL]
 - `screenshot_count`: 截图生成的张数，默认为0，即不生成截图
 - `image_hosting`: 图床的名称，现在支持ptpimg,chevereto,imgurl和SM.MS
 - `image_hosting_url`: 如果是自建的图床，提供图床链接
-- `ptgen_url`: PTGen的地址，默认是我自建的PTGen，可能会不稳定
 - `announce_url`: 制种时的announce地址
 - `encoder_log`: 压制log的地址，如果提供的话会在介绍的mediainfo部分附上压制log
 - `easy_upload`: 默认关闭，开启的话会利用[easy-upload](https://github.com/techmovie/easy-upload)自动填充发种页面表单

--- a/config.ini.example
+++ b/config.ini.example
@@ -23,8 +23,7 @@ easy_upload = true
 ; 使用差速器自带的短网址服务
 use_short_url = true
 
-; 差速器自带一个自建的PTGen，如果无法访问，可以提供自定义PTGen地址
-;ptgen_url = https://XXXXX.com
+; 差速器会自动依次使用PtGen Archive的Ourhelp CDN、GitHub Pages和Ourhelp API provider
 
 [NexusPHP]
 ; 发种页面的链接

--- a/src/differential/base_plugin.py
+++ b/src/differential/base_plugin.py
@@ -253,15 +253,6 @@ class Base(ABC, TorrnetBase, metaclass=PluginRegister):
             default=argparse.SUPPRESS,
         )
         parser.add_argument(
-            "--ptgen-url", type=str, help="自定义PTGEN的地址", default=argparse.SUPPRESS
-        )
-        parser.add_argument(
-            "--ptgen-retry",
-            type=int,
-            help="PTGEN重试次数，默认为3次",
-            default=argparse.SUPPRESS,
-        )
-        parser.add_argument(
             "--announce-url",
             type=str,
             help="制种时announce地址",
@@ -348,10 +339,7 @@ class Base(ABC, TorrnetBase, metaclass=PluginRegister):
         lsky_token: str = None,
         lsky_email: str = None,
         lsky_password: str = None,
-        ptgen_url: str = "https://ptgen.lgto.workers.dev",
-        second_ptgen_url: str = "https://api.slyw.me",
         announce_url: str = "https://example.com",
-        ptgen_retry: int = 3,
         generate_nfo: bool = False,
         make_torrent: bool = False,
         easy_upload: bool = False,
@@ -386,9 +374,6 @@ class Base(ABC, TorrnetBase, metaclass=PluginRegister):
         )
         self.ptgen_handler = PTGenHandler(
             url=self.url,
-            ptgen_url=ptgen_url,
-            second_ptgen_url=second_ptgen_url,
-            ptgen_retry=ptgen_retry,
         )
         self.screenshot_handler = ScreenshotHandler(
             folder=self.folder,

--- a/src/differential/utils/ptgen/bangumi.py
+++ b/src/differential/utils/ptgen/bangumi.py
@@ -12,16 +12,21 @@ class BangumiData(PTGenData):
     cover: Optional[str] = None  # for backward compatibility
     poster: Optional[str] = None
     story: Optional[str] = None
+    name: Optional[str] = None
+    name_cn: Optional[str] = None
+    date: Optional[str] = None
+    eps: Optional[int] = None
+    platform: Optional[str] = None
 
     # staff: e.g. ["导演: XXX", "脚本: YYY", ...]
-    staff: List[str] = field(default_factory=list)
+    staff: List[Any] = field(default_factory=list)
     # info: e.g. ["中文名: XXX", "别名: YYY", ...]
     info: List[str] = field(default_factory=list)
 
     bangumi_votes: Optional[str] = None
     bangumi_rating_average: Optional[str] = None
-    tags: List[str] = field(default_factory=list)
-    cast: List[str] = field(default_factory=list)
+    tags: List[Any] = field(default_factory=list)
+    cast: List[Any] = field(default_factory=list)
 
     @staticmethod
     def from_dict(obj: Dict[str, Any]) -> 'BangumiData':
@@ -39,18 +44,37 @@ class BangumiData(PTGenData):
 
         bangumi = BangumiData(**base.__dict__)
 
-        bangumi.alt = obj.get('alt')
+        bangumi.alt = obj.get('alt') or (f"https://bgm.tv/subject/{obj.get('sid')}" if obj.get('sid') else None)
         bangumi.cover = obj.get('cover')
-        bangumi.poster = obj.get('poster')
+        bangumi.poster = obj.get('poster') or obj.get('cover')
         bangumi.story = obj.get('story')
+        bangumi.name = obj.get('name')
+        bangumi.name_cn = obj.get('name_cn')
+        bangumi.date = obj.get('date')
+        bangumi.eps = obj.get('eps')
+        bangumi.platform = obj.get('platform')
 
         # Staff & Info
         bangumi.staff = obj.get('staff', [])
         bangumi.info = obj.get('info', [])
+        if not bangumi.info:
+            bangumi.info = [
+                f"{key}: {value}"
+                for key, value in (
+                    ("中文名", bangumi.name_cn),
+                    ("放送日期", bangumi.date),
+                    ("话数", bangumi.eps),
+                    ("平台", bangumi.platform),
+                )
+                if value
+            ]
 
         # Ratings
         bangumi.bangumi_votes = obj.get('bangumi_votes')
         bangumi.bangumi_rating_average = obj.get('bangumi_rating_average')
+        if isinstance(obj.get('rating'), dict):
+            bangumi.bangumi_votes = obj['rating'].get('total')
+            bangumi.bangumi_rating_average = obj['rating'].get('score')
 
         # Tags & Cast
         bangumi.tags = obj.get('tags', [])
@@ -59,6 +83,10 @@ class BangumiData(PTGenData):
         return bangumi
 
     def __str__(self) -> str:
+        if self.name_cn:
+            return self.name_cn
+        if self.name:
+            return self.name
         # Extract Chinese name from info if available
         for info_item in self.info:
             if info_item.startswith('中文名:'):

--- a/src/differential/utils/ptgen/base.py
+++ b/src/differential/utils/ptgen/base.py
@@ -10,10 +10,10 @@ class DataType(Enum):
 
     @classmethod
     def from_str(cls, value: str) -> Optional['DataType']:
-        value = value.lower().strip()
+        value = str(value or "").lower().strip()
         if value in ["movie", "电影"]:
             return cls.MOVIE
-        elif value in ["TVSeries", "tv series", "电视剧", "剧集"]:
+        elif value in ["tvseries", "tv series", "电视剧", "剧集"]:
             return cls.TV_SERIES
         return None
 

--- a/src/differential/utils/ptgen/douban.py
+++ b/src/differential/utils/ptgen/douban.py
@@ -60,7 +60,7 @@ class DoubanData(PTGenData):
             success=obj.get('success', False),
             error=obj.get('error'),
             format=obj.get('format'),
-            type_=DataType.TV_SERIES if obj.get('episodes', '').isdigit() else DataType.MOVIE
+            type_=DataType.TV_SERIES if str(obj.get('episodes') or '').isdigit() else DataType.MOVIE
         )
         douban = DoubanData(**base.__dict__)
 

--- a/src/differential/utils/ptgen/epic.py
+++ b/src/differential/utils/ptgen/epic.py
@@ -8,6 +8,7 @@ class EpicData(PTGenData):
     """ Dataclass for data returned from epic.js """
     name: Optional[str] = None
     epic_link: Optional[str] = None
+    logo: Optional[str] = None
     desc: Optional[str] = None
     poster: Optional[str] = None
     screenshot: List[str] = field(default_factory=list)
@@ -34,8 +35,9 @@ class EpicData(PTGenData):
 
         epic.name = obj.get('name')
         epic.epic_link = obj.get('epic_link')
+        epic.logo = obj.get('logo')
         epic.desc = obj.get('desc')
-        epic.poster = obj.get('poster')
+        epic.poster = obj.get('poster') or obj.get('logo')
         epic.screenshot = obj.get('screenshot', [])
         epic.language = obj.get('language', [])
         epic.min_req = obj.get('min_req', {})

--- a/src/differential/utils/ptgen/formatter.py
+++ b/src/differential/utils/ptgen/formatter.py
@@ -1,0 +1,507 @@
+import re
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+
+
+def build_ptgen_format(data: Mapping[str, Any]) -> str:
+    current_format = _clean_text(data.get("format"))
+    if current_format:
+        return current_format
+
+    formatter = _FORMATTERS.get(_clean_text(data.get("site")), _format_generic)
+    rendered = formatter(data).strip()
+    if rendered:
+        return rendered
+    return _format_generic(data).strip()
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return text
+
+
+def _first_text(*values: Any) -> str:
+    for value in values:
+        text = _clean_text(value)
+        if text:
+            return text
+    return ""
+
+
+def _as_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _join(value: Any, sep: str = " / ") -> str:
+    parts: List[str] = []
+    seen = set()
+    for item in _as_list(value):
+        text = _clean_text(item)
+        if text and text not in seen:
+            parts.append(text)
+            seen.add(text)
+    return sep.join(parts)
+
+
+def _people(value: Any, limit: Optional[int] = None) -> str:
+    names: List[str] = []
+    for item in _as_list(value):
+        if isinstance(item, dict):
+            name = _first_text(item.get("name"), item.get("value"), item.get("title"))
+        else:
+            name = _clean_text(item)
+        if name:
+            names.append(name)
+    if limit:
+        names = names[:limit]
+    return " / ".join(names)
+
+
+def _people_multiline(value: Any) -> str:
+    names = _people(value).split(" / ")
+    names = [name for name in names if name]
+    if not names:
+        return ""
+    return ("\n" + "　" * 4 + "  　").join(names).strip()
+
+
+def _field(lines: List[str], label: str, value: Any) -> None:
+    text = _join(value) if isinstance(value, (list, tuple)) else _clean_text(value)
+    if text:
+        lines.append(f"{label}{text}")
+
+
+def _section(lines: List[str], title: str, body: Any) -> None:
+    body_text = _block_text(body)
+    if not body_text:
+        return
+    lines.extend(["", title, "", body_text])
+
+
+def _block_text(value: Any) -> str:
+    if isinstance(value, dict):
+        return "\n".join(_dict_lines(value))
+    if isinstance(value, (list, tuple)):
+        return "\n".join(_clean_text(v) for v in value if _clean_text(v))
+    return _clean_text(value)
+
+
+def _dict_lines(value: Mapping[str, Any]) -> List[str]:
+    lines: List[str] = []
+    for key, item in value.items():
+        if isinstance(item, (list, tuple)):
+            item_text = "\n".join(_clean_text(i) for i in item if _clean_text(i))
+            if item_text:
+                lines.append(f"{key}\n{item_text}")
+        else:
+            item_text = _clean_text(item)
+            if item_text:
+                lines.append(f"{key}: {item_text}")
+    return lines
+
+
+def _image(data: Mapping[str, Any]) -> str:
+    url = _first_text(data.get("poster"), data.get("cover"), data.get("logo"))
+    return f"[img]{url}[/img]" if url else ""
+
+
+def _start_lines(data: Mapping[str, Any]) -> List[str]:
+    image = _image(data)
+    return [image, ""] if image else []
+
+
+def _start_lines_with_url(url: str) -> List[str]:
+    text = _clean_text(url)
+    return [f"[img]{text}[/img]", ""] if text else []
+
+
+def _indent_text(value: str, prefix: str) -> str:
+    return _clean_text(value).replace("\n", "\n" + prefix)
+
+
+def _rating(average: Any, votes: Any) -> str:
+    avg = _clean_text(average)
+    vote_count = _clean_text(votes)
+    if avg and vote_count:
+        return f"{avg}/10 from {vote_count} users"
+    return avg
+
+
+def _format_douban(data: Mapping[str, Any]) -> str:
+    lines = _start_lines(data)
+    sid = _clean_text(data.get("sid"))
+    trans_title = _join(
+        [
+            data.get("chinese_title"),
+            *_as_list(data.get("trans_title")),
+            *_as_list(data.get("aka")),
+        ]
+    )
+    douban_link = _first_text(
+        data.get("douban_link"),
+        f"https://movie.douban.com/subject/{sid}/" if sid else "",
+    )
+    _field(lines, "◎译　　名　", trans_title)
+    _field(lines, "◎片　　名　", _first_text(data.get("foreign_title"), _join(data.get("this_title"))))
+    _field(lines, "◎年　　代　", data.get("year"))
+    _field(lines, "◎产　　地　", data.get("region"))
+    _field(lines, "◎类　　别　", data.get("genre"))
+    _field(lines, "◎语　　言　", data.get("language"))
+    _field(lines, "◎上映日期　", data.get("playdate"))
+    _field(
+        lines,
+        "◎IMDb评分  ",
+        _first_text(
+            data.get("imdb_rating"),
+            _rating(data.get("imdb_rating_average"), data.get("imdb_votes")),
+        ),
+    )
+    _field(lines, "◎IMDb链接  ", data.get("imdb_link"))
+    _field(
+        lines,
+        "◎豆瓣评分　",
+        _first_text(
+            data.get("douban_rating"),
+            _rating(data.get("douban_rating_average"), data.get("douban_votes")),
+        ),
+    )
+    _field(lines, "◎豆瓣链接　", douban_link)
+    _field(lines, "◎集　　数　", data.get("episodes"))
+    _field(lines, "◎片　　长　", data.get("duration"))
+    _field(lines, "◎导　　演　", _people(data.get("director")))
+    _field(lines, "◎编　　剧　", _people(data.get("writer")))
+    _field(lines, "◎主　　演　", _people_multiline(data.get("cast")))
+    tags = _join(data.get("tags"), sep=" | ")
+    if tags:
+        lines.extend(["", f"◎标　　签　{tags}"])
+    introduction = _clean_text(data.get("introduction"))
+    if introduction:
+        lines.extend(["", "◎简　　介", "", f"　　{_indent_text(introduction, '　　')}"])
+    awards = _clean_text(data.get("awards"))
+    if awards:
+        lines.extend(["", "◎获奖情况", "", f"　　{_indent_text(awards, '　　')}"])
+    return "\n".join(lines)
+
+
+def _format_imdb(data: Mapping[str, Any]) -> str:
+    lines = _start_lines(data)
+    sid = _clean_text(data.get("sid"))
+    _field(lines, "Title: ", data.get("name"))
+    _field(lines, "Keywords: ", data.get("keywords"))
+    _field(lines, "Date Published: ", data.get("datePublished"))
+    _field(
+        lines,
+        "IMDb Rating: ",
+        _first_text(
+            data.get("imdb_rating"),
+            _rating(data.get("imdb_rating_average"), data.get("imdb_votes")),
+        ),
+    )
+    _field(
+        lines,
+        "IMDb Link: ",
+        _first_text(data.get("imdb_link"), f"https://www.imdb.com/title/{sid}/" if sid else ""),
+    )
+    _field(lines, "Directors: ", _people(data.get("directors")))
+    _field(lines, "Creators: ", _people(data.get("creators")))
+    _field(lines, "Actors: ", _people(data.get("actors")))
+    description = _clean_text(data.get("description"))
+    if description:
+        lines.extend(["", "Introduction", f"    {_indent_text(description, '　　')}"])
+    return "\n".join(lines)
+
+
+def _format_steam(data: Mapping[str, Any]) -> str:
+    lines = _start_lines(data)
+    lines.extend(["【基本信息】", ""])
+    _field(lines, "中文名: ", data.get("name_chs"))
+    detail = _clean_text(data.get("detail"))
+    if detail:
+        lines.append(detail)
+    _field(lines, "官方网站: ", data.get("linkbar"))
+    steam_page = _first_text(
+        data.get("steam_link"),
+        f"https://store.steampowered.com/app/{data.get('steam_id')}/" if data.get("steam_id") else "",
+    )
+    _field(lines, "Steam页面: ", steam_page)
+    _field(lines, "游戏语种: ", _join(data.get("language"), sep=" | "))
+    _field(lines, "标签: ", _join(data.get("tags"), sep=" | "))
+    reviews = _block_text(data.get("review"))
+    if reviews:
+        lines.extend(["", reviews])
+    lines.append("")
+    descr = _clean_text(data.get("descr"))
+    if descr:
+        lines.extend(["【游戏简介】", "", descr, ""])
+    sysreq = _block_text(data.get("sysreq"))
+    if sysreq:
+        lines.extend(["【配置需求】", "", sysreq, ""])
+    screenshots = _image_list(data.get("screenshot"))
+    if screenshots:
+        lines.extend(["【游戏截图】", "", "\n".join(screenshots), ""])
+    return "\n".join(lines).strip()
+
+
+def _format_epic(data: Mapping[str, Any]) -> str:
+    lines = _start_lines_with_url(_first_text(data.get("logo"), data.get("poster"), data.get("cover")))
+    lines.extend(["【基本信息】", ""])
+    _field(lines, "游戏名称：", data.get("name"))
+    _field(lines, "商店链接：", data.get("epic_link"))
+    lines.append("")
+    language = _block_text(data.get("language"))
+    if language:
+        lines.extend(["【支持语言】", "", language, ""])
+    desc = _markdown_images_to_bbcode(data.get("desc"))
+    if desc:
+        lines.extend(["【游戏简介】", "", desc, ""])
+    for key, title in (("min_req", "【最低配置】"), ("max_req", "【推荐配置】")):
+        req_text = _requirement_text(data.get(key))
+        if req_text:
+            lines.extend([title, "", req_text, ""])
+    screenshots = _image_list(data.get("screenshot"))
+    if screenshots:
+        lines.extend(["【游戏截图】", "", "\n".join(screenshots), ""])
+    levels = _image_list(data.get("level"))
+    if levels:
+        lines.extend(["【游戏评级】", "", "\n".join(levels), ""])
+    return "\n".join(lines).strip()
+
+
+def _format_bangumi(data: Mapping[str, Any]) -> str:
+    lines = _start_lines(data)
+    story = _clean_text(data.get("story"))
+    if story:
+        lines.extend(["[b]Story: [/b]", "", story, ""])
+    staff = _key_value_list(data.get("staff"))[:15]
+    if staff:
+        lines.extend(["[b]Staff: [/b]", "", "\n".join(staff), ""])
+    cast = _bangumi_cast(data.get("cast"))[:9]
+    if cast:
+        lines.extend(["[b]Cast: [/b]", "", "\n".join(cast), ""])
+    alt = _clean_text(data.get("alt"))
+    if alt:
+        lines.append(f"(来源于 {alt} )")
+    return "\n".join(lines).strip()
+
+
+def _format_indienova(data: Mapping[str, Any]) -> str:
+    lines = _start_lines_with_url(_first_text(data.get("cover"), data.get("poster")))
+    lines.extend(["【基本信息】", ""])
+    _field(lines, "中文名称：", data.get("chinese_title"))
+    _field(lines, "英文名称：", data.get("english_title"))
+    _field(lines, "其他名称：", data.get("another_title"))
+    _field(lines, "发行时间：", data.get("release_date"))
+    _field(lines, "评分：", data.get("rate"))
+    _field(lines, "开发商：", _join(data.get("dev")))
+    _field(lines, "发行商：", _join(data.get("pub")))
+    intro_detail = _block_text(data.get("intro_detail"))
+    if intro_detail:
+        lines.append(intro_detail)
+    tags = _join(_as_list(data.get("cat"))[:8], sep=" | ")
+    _field(lines, "标签：", tags)
+    links = _links_text(data.get("links"))
+    if links:
+        lines.append(f"链接地址：{links}")
+    price = _join(data.get("price"))
+    _field(lines, "价格信息：", price)
+    lines.append("")
+    descr = _clean_text(data.get("descr"))
+    if descr:
+        lines.extend(["【游戏简介】", "", descr, ""])
+    screenshots = _image_list(data.get("screenshot"))
+    if screenshots:
+        lines.extend(["【游戏截图】", "", "\n".join(screenshots), ""])
+    levels = _image_list(data.get("level"))
+    if levels:
+        lines.extend(["【游戏评级】", "", "\n".join(levels), ""])
+    return "\n".join(lines).strip()
+
+
+def _format_douban_person(data: Mapping[str, Any]) -> str:
+    lines = _start_lines(data)
+    imdb_id = _clean_text(data.get("imdb_id"))
+    name = _first_text(data.get("name_full"), _join([data.get("name"), data.get("name_en")]), data.get("name"))
+    _field(lines, "姓名: ", name)
+    _field(lines, "更多中文名: ", data.get("name_more_cn"))
+    _field(lines, "更多外文名: ", data.get("name_more_other"))
+    _field(lines, "性别: ", data.get("gender"))
+    _field(lines, "出生日期: ", data.get("birth_date"))
+    _field(lines, "出生地: ", data.get("birth_place"))
+    _field(lines, "职业: ", data.get("roles"))
+    _field(lines, "IMDb编号: ", imdb_id)
+    _field(lines, "IMDb链接: ", f"https://www.imdb.com/name/{imdb_id}/" if imdb_id else "")
+    _field(lines, "豆瓣影人: ", data.get("celebrity_link"))
+    _field(lines, "豆瓣人物: ", data.get("personage_link"))
+    _section(lines, "简介", data.get("introduction"))
+    _section(lines, "获奖情况", _person_awards(data.get("awards")))
+    _section(lines, "近期作品", _movie_titles(data.get("last_movies")))
+    return "\n".join(lines)
+
+
+def _format_generic(data: Mapping[str, Any]) -> str:
+    lines = _start_lines(data)
+    _field(
+        lines,
+        "Title: ",
+        _first_text(
+            data.get("chinese_title"),
+            data.get("name_cn"),
+            data.get("name_chs"),
+            data.get("name"),
+            data.get("foreign_title"),
+            data.get("sid"),
+        ),
+    )
+    _field(lines, "Site: ", data.get("site"))
+    _field(lines, "ID: ", data.get("sid"))
+    for key in ("douban_link", "imdb_link", "steam_link", "epic_link", "alt"):
+        _field(lines, f"{key}: ", data.get(key))
+    _section(
+        lines,
+        "Introduction",
+        _first_text(
+            data.get("introduction"),
+            data.get("description"),
+            data.get("descr"),
+            data.get("desc"),
+            data.get("story"),
+            data.get("intro"),
+        ),
+    )
+    return "\n".join(lines)
+
+
+def _image_list(value: Any) -> List[str]:
+    return [f"[img]{url}[/img]" for url in _as_text_iter(value)]
+
+
+def _as_text_iter(value: Any) -> Iterable[str]:
+    for item in _as_list(value):
+        text = _clean_text(item)
+        if text:
+            yield text
+
+
+def _markdown_images_to_bbcode(value: Any) -> str:
+    text = _clean_text(value)
+    if not text:
+        return ""
+    # Handle the simple image syntax seen in the Epic archive without pulling in markdown.
+    return re.sub(r"!\[[^\]]*\]\s*\(([^)]+)\)", r"[img]\1[/img]", text, count=1)
+
+
+def _links_text(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return _join(value, sep="  ")
+    links: List[str] = []
+    for key, link in value.items():
+        link_text = _clean_text(link)
+        key_text = _clean_text(key)
+        if key_text and link_text:
+            links.append(f"[url={link_text}]{key_text}[/url]")
+    return "  ".join(links)
+
+
+def _requirement_text(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return _block_text(value)
+
+    lines: List[str] = []
+    for system, requirements in value.items():
+        req_text = _block_text(requirements)
+        if req_text:
+            lines.append(f"{system}\n{req_text}")
+    return "\n".join(lines)
+
+
+def _key_value_list(value: Any) -> List[str]:
+    lines: List[str] = []
+    for item in _as_list(value):
+        if isinstance(item, dict):
+            line = _first_text(item.get("key"))
+            item_value = _clean_text(item.get("value"))
+            if line and item_value:
+                lines.append(f"{line}: {item_value}")
+            elif item_value:
+                lines.append(item_value)
+        else:
+            text = _clean_text(item)
+            if text:
+                lines.append(text)
+    return lines
+
+
+def _bangumi_rating(value: Any) -> str:
+    if not isinstance(value, dict):
+        return _clean_text(value)
+    score = _clean_text(value.get("score"))
+    total = _clean_text(value.get("total"))
+    if score and total:
+        return f"{score}/10 from {total} users"
+    return score
+
+
+def _bangumi_cast(value: Any) -> List[str]:
+    lines: List[str] = []
+    for item in _as_list(value):
+        if not isinstance(item, dict):
+            text = _clean_text(item)
+            if text:
+                lines.append(text)
+            continue
+
+        name = _clean_text(item.get("name"))
+        actors = _people(item.get("actors"))
+        relation = _clean_text(item.get("relation"))
+        chunks = [chunk for chunk in (name, actors, relation) if chunk]
+        if chunks:
+            lines.append(" / ".join(chunks))
+    return lines
+
+
+def _person_awards(value: Any) -> List[str]:
+    lines: List[str] = []
+    for item in _as_list(value):
+        if isinstance(item, dict):
+            text = _join([item.get("year"), item.get("title"), item.get("award"), item.get("result")])
+        else:
+            text = _clean_text(item)
+        if text:
+            lines.append(text)
+    return lines
+
+
+def _movie_titles(value: Any) -> List[str]:
+    lines: List[str] = []
+    for item in _as_list(value):
+        if isinstance(item, dict):
+            title = _clean_text(item.get("title"))
+            year = _clean_text(item.get("year"))
+            if title and year:
+                lines.append(f"{title} ({year})")
+            elif title:
+                lines.append(title)
+        else:
+            text = _clean_text(item)
+            if text:
+                lines.append(text)
+    return lines
+
+
+_FORMATTERS: Dict[str, Callable[[Mapping[str, Any]], str]] = {
+    "douban": _format_douban,
+    "douban_celebrity": _format_douban_person,
+    "douban_personage": _format_douban_person,
+    "imdb": _format_imdb,
+    "steam": _format_steam,
+    "epic": _format_epic,
+    "bangumi": _format_bangumi,
+    "indienova": _format_indienova,
+}

--- a/src/differential/utils/ptgen/indienova.py
+++ b/src/differential/utils/ptgen/indienova.py
@@ -43,7 +43,7 @@ class IndienovaData(PTGenData):
         indienova = IndienovaData(**base.__dict__)
 
         indienova.cover = obj.get('cover')
-        indienova.poster = obj.get('poster')
+        indienova.poster = obj.get('poster') or obj.get('cover')
         indienova.chinese_title = obj.get('chinese_title')
         indienova.another_title = obj.get('another_title')
         indienova.english_title = obj.get('english_title')

--- a/src/differential/utils/ptgen/providers.py
+++ b/src/differential/utils/ptgen/providers.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Protocol, Sequence
+from urllib.parse import quote
+
+import requests
+
+from differential.utils.ptgen.reference import PTGenReference
+
+
+class PTGenProviderError(Exception):
+    pass
+
+
+class PTGenProvider(Protocol):
+    name: str
+
+    def fetch(
+        self,
+        reference: PTGenReference,
+        session: requests.Session,
+        timeout: int,
+    ) -> Dict[str, Any]:
+        ...
+
+
+def _response_json(provider_name: str, response: requests.Response) -> Dict[str, Any]:
+    if not response.ok:
+        raise PTGenProviderError(
+            f"{provider_name} HTTP {response.status_code} - {response.reason}"
+        )
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise PTGenProviderError(f"{provider_name} returned invalid JSON") from exc
+
+    if not isinstance(data, dict):
+        raise PTGenProviderError(f"{provider_name} returned non-object JSON")
+    return data
+
+
+@dataclass(frozen=True)
+class StaticPtGenProvider:
+    name: str
+    base_url: str
+
+    def url_for(self, reference: PTGenReference) -> str:
+        site = quote(reference.site, safe="")
+        sid = quote(reference.sid, safe="")
+        return f"{self.base_url.rstrip('/')}/{site}/{sid}.json"
+
+    def fetch(
+        self,
+        reference: PTGenReference,
+        session: requests.Session,
+        timeout: int,
+    ) -> Dict[str, Any]:
+        response = session.get(self.url_for(reference), timeout=timeout)
+        return _response_json(self.name, response)
+
+
+@dataclass(frozen=True)
+class ApiPtGenProvider:
+    name: str
+    base_url: str
+
+    def fetch(
+        self,
+        reference: PTGenReference,
+        session: requests.Session,
+        timeout: int,
+    ) -> Dict[str, Any]:
+        response = session.get(
+            self.base_url,
+            params={"site": reference.site, "sid": reference.sid},
+            timeout=timeout,
+        )
+        return _response_json(self.name, response)
+
+
+DEFAULT_PTGEN_PROVIDERS: Sequence[PTGenProvider] = (
+    StaticPtGenProvider(
+        name="ourhelp-cdn",
+        base_url="https://cdn.ourhelp.club/ptgen",
+    ),
+    StaticPtGenProvider(
+        name="github-pages",
+        base_url="https://ourbits.github.io/PtGen",
+    ),
+    ApiPtGenProvider(
+        name="ourhelp-api",
+        base_url="https://api.ourhelp.club/infogen",
+    ),
+)

--- a/src/differential/utils/ptgen/reference.py
+++ b/src/differential/utils/ptgen/reference.py
@@ -1,0 +1,83 @@
+import re
+from dataclasses import dataclass
+from typing import Optional, Pattern, Tuple
+
+
+@dataclass(frozen=True)
+class PTGenReference:
+    site: str
+    sid: str
+    original_url: str
+
+
+_REFERENCE_PATTERNS: Tuple[Tuple[str, Pattern[str]], ...] = (
+    (
+        "douban_celebrity",
+        re.compile(
+            r"(?:https?://)?movie\.douban\.com/celebrity/(?P<sid>\d+)/?",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "douban_personage",
+        re.compile(
+            r"(?:https?://)?www\.douban\.com/personage/(?P<sid>\d+)/?",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "douban",
+        re.compile(
+            r"(?:https?://)?(?:(?:movie|www)\.)?douban\.com/(?:subject|movie)/(?P<sid>\d+)/?",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "imdb",
+        re.compile(
+            r"(?:https?://)?(?:www\.)?imdb\.com/title/(?P<sid>tt\d+)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "bangumi",
+        re.compile(
+            r"(?:https?://)?(?:bgm\.tv|bangumi\.tv|chii\.in)/subject/(?P<sid>\d+)/?",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "steam",
+        re.compile(
+            r"(?:https?://)?(?:(?:store\.)?steampowered|steamcommunity)\.com/app/(?P<sid>\d+)/?",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "indienova",
+        re.compile(
+            r"(?:https?://)?indienova\.com/game/(?P<sid>[^/?#]+)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "epic",
+        re.compile(
+            r"(?:https?://)?www\.epicgames\.com/store/[a-zA-Z-]+/product/(?P<sid>[^/?#]+)/?",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+
+def parse_ptgen_reference(url: str) -> Optional[PTGenReference]:
+    candidate = (url or "").strip()
+    for site, pattern in _REFERENCE_PATTERNS:
+        match = pattern.search(candidate)
+        if match:
+            return PTGenReference(
+                site=site,
+                sid=match.group("sid").rstrip("/"),
+                original_url=url,
+            )
+    return None

--- a/src/differential/utils/ptgen/steam.py
+++ b/src/differential/utils/ptgen/steam.py
@@ -7,6 +7,8 @@ from differential.utils.ptgen.base import PTGenData, DataType
 class SteamData(PTGenData):
     """ Dataclass for data returned from steam.js """
     steam_id: Optional[str] = None
+    steam_link: Optional[str] = None
+    cover: Optional[str] = None
     poster: Optional[str] = None
     name: Optional[str] = None
     detail: Optional[str] = None
@@ -32,7 +34,9 @@ class SteamData(PTGenData):
         steam = SteamData(**base.__dict__)
 
         steam.steam_id = obj.get('steam_id')
-        steam.poster = obj.get('poster')
+        steam.steam_link = obj.get('steam_link')
+        steam.cover = obj.get('cover')
+        steam.poster = obj.get('poster') or obj.get('cover')
         steam.name = obj.get('name')
         steam.detail = obj.get('detail')
         steam.tags = obj.get('tags', [])

--- a/src/differential/utils/ptgen_handler.py
+++ b/src/differential/utils/ptgen_handler.py
@@ -1,22 +1,61 @@
-import requests
 from loguru import logger
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Sequence
 
 from differential.utils.ptgen.base import PTGenData
 from differential.utils.ptgen.imdb import IMDBData
 from differential.utils.ptgen.douban import DoubanData
+from differential.utils.ptgen.formatter import build_ptgen_format
 from differential.utils.ptgen.parser import parse_ptgen
+from differential.utils.ptgen.providers import (
+    DEFAULT_PTGEN_PROVIDERS,
+    PTGenProvider,
+    PTGenProviderError,
+)
+from differential.utils.ptgen.reference import PTGenReference, parse_ptgen_reference
+
+import requests
+
+
+FAILURE_FORMAT = "PTGen获取失败，请自行获取相关内容"
+
+
+def normalize_ptgen_payload(data: Dict[str, Any], reference: PTGenReference) -> Dict[str, Any]:
+    if not isinstance(data, dict):
+        raise PTGenProviderError("provider returned non-object JSON")
+
+    payload = dict(data)
+    site = str(payload.get("site") or reference.site)
+    sid = str(payload.get("sid") or reference.sid)
+
+    if site != reference.site or sid != reference.sid:
+        raise PTGenProviderError(
+            f"provider returned mismatched data: expected {reference.site}/{reference.sid}, got {site}/{sid}"
+        )
+
+    if payload.get("success") is False:
+        raise PTGenProviderError(payload.get("error") or "provider returned success=false")
+
+    payload["site"] = site
+    payload["sid"] = sid
+    payload["success"] = True if payload.get("success") is None else payload["success"]
+    payload["format"] = build_ptgen_format(payload)
+    return payload
 
 class PTGenHandler:
     """
-    Handles fetching information from PTGen (and optionally IMDB).
+    Handles fetching information from PtGen archive providers.
     """
 
-    def __init__(self, url: str, ptgen_url: str, second_ptgen_url: str, ptgen_retry: int):
+    def __init__(
+        self,
+        url: str,
+        providers: Sequence[PTGenProvider] = DEFAULT_PTGEN_PROVIDERS,
+        timeout: int = 15,
+    ):
         self.url = url
-        self.ptgen_url = ptgen_url
-        self.second_ptgen_url = second_ptgen_url
-        self.ptgen_retry = ptgen_retry
+        self.providers = tuple(providers)
+        self.timeout = timeout
+        self.session = requests.Session()
 
         self._ptgen: Optional[PTGenData] = None
         self._douban: Optional[DoubanData] = None
@@ -24,60 +63,76 @@ class PTGenHandler:
 
     def fetch_ptgen_info(self):
         """
-        Public method to fetch PTGen (and optional IMDB) data,
-        with retry logic switching between ptgen_url and second_ptgen_url.
+        Public method to fetch PtGen data and optional IMDB data.
         """
-        attempts_left = 2 * self.ptgen_retry
-        while attempts_left > 0:
-            use_second = attempts_left <= self.ptgen_retry
-            self._ptgen = self._request_ptgen_info(use_second=use_second)
-            if self._ptgen.success:
-                return (self._ptgen, self._douban, self._imdb)
-            attempts_left -= 1
+        reference = parse_ptgen_reference(self.url)
+        if not reference:
+            self._ptgen = PTGenData(
+                success=False,
+                error=f"不支持的PTGen链接: {self.url}",
+                format=FAILURE_FORMAT,
+            )
+            logger.warning(f"[PTGen] 不支持的链接: {self.url}")
+            return (self._ptgen, self._douban, self._imdb)
 
+        self._ptgen = self._request_ptgen_info(reference)
+        if self._ptgen.success:
+            if self._ptgen.site != "imdb":
+                if self._ptgen.site == "douban":
+                    self._douban = self._ptgen
+                imdb_link = getattr(self._ptgen, "imdb_link", None)
+                if imdb_link:
+                    self._imdb = self._try_fetch_imdb(imdb_link)
+            else:
+                self._imdb = self._ptgen
         return (self._ptgen, self._douban, self._imdb)
 
-    def _request_ptgen_info(self, use_second: bool = False) -> PTGenData:
-        ptgen_url = self.second_ptgen_url if use_second else self.ptgen_url
-        logger.debug(f"[PTGen] 正在从 {ptgen_url} 获取 {self.url}")
-        params = {"url": self.url}
+    def _request_ptgen_info(self, reference: PTGenReference) -> PTGenData:
+        last_error = ""
+        for provider in self.providers:
+            logger.debug(
+                f"[PTGen] 正在从 {provider.name} 获取 {reference.site}/{reference.sid}"
+            )
+            try:
+                raw_data = provider.fetch(reference, self.session, self.timeout)
+                payload = normalize_ptgen_payload(raw_data, reference)
+                ptgen = parse_ptgen(payload)
+                if not ptgen.success:
+                    last_error = ptgen.error or "PTGen解析失败"
+                    logger.warning(f"[PTGen] {provider.name} 获取失败: {last_error}")
+                    continue
 
-        try:
-            resp = requests.get(ptgen_url, params=params, timeout=15)
-            if not resp.ok:
-                logger.trace(resp.content)
-                logger.warning(f"[PTGen] HTTP {resp.status_code} - {resp.reason}")
-                return PTGenData()
-
-            ptgen = parse_ptgen(resp.json())
-            if not ptgen.success:
-                logger.trace(resp.json())
-                logger.warning(f"[PTGen] 获取失败: {ptgen.error}")
+                logger.info(f"[PTGen] {provider.name} 获取成功: {ptgen}")
                 return ptgen
-            
-            if ptgen.site != "imdb":
-                if ptgen.site == 'douban':
-                    self._douban = ptgen
-                if hasattr(ptgen, "imdb_link"):
-                    self._imdb = self._try_fetch_imdb(ptgen.imdb_link)
-            else:
-                self._imdb = ptgen
+            except Exception as e:
+                last_error = str(e)
+                logger.warning(f"[PTGen] {provider.name} 获取失败: {last_error}")
 
-            logger.info(f"[PTGen] 获取成功: {ptgen}")
-            return ptgen
-        except requests.RequestException as e:
-            logger.warning(f"[PTGen] 请求异常: {e}")
-            return PTGenData()
+        return PTGenData(
+            site=reference.site,
+            sid=reference.sid,
+            success=False,
+            error=last_error or "所有PTGen provider均获取失败",
+            format=FAILURE_FORMAT,
+        )
 
     def _try_fetch_imdb(self, imdb_link: str) -> IMDBData:
         """
-        Attempt to fetch IMDB info from PTGen for the provided IMDB link.
-        Returns a dict or empty if failed.
+        Attempt to fetch IMDB info from PtGen providers for the provided IMDB link.
         """
-        try:
-            req = requests.get(self.ptgen_url, params={"url": imdb_link}, timeout=15)
-            if req.ok and req.json().get("success"):
-                return IMDBData.from_dict(req.json())
-        except Exception as e:
-            logger.warning(f"[IMDB] 请求异常: {e}")
-        return IMDBData()
+        reference = parse_ptgen_reference(imdb_link)
+        if not reference:
+            logger.warning(f"[IMDB] 不支持的链接: {imdb_link}")
+            return IMDBData(format=FAILURE_FORMAT)
+
+        ptgen = self._request_ptgen_info(reference)
+        if isinstance(ptgen, IMDBData):
+            return ptgen
+
+        return IMDBData(
+            site=reference.site,
+            sid=reference.sid,
+            success=False,
+            error=ptgen.error,
+            format=ptgen.format or FAILURE_FORMAT,
+        )

--- a/tests/test_ptgen_providers.py
+++ b/tests/test_ptgen_providers.py
@@ -1,0 +1,422 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from differential.utils.ptgen.douban import DoubanData
+from differential.utils.ptgen.formatter import build_ptgen_format
+from differential.utils.ptgen.imdb import IMDBData
+from differential.utils.ptgen.providers import (
+    ApiPtGenProvider,
+    DEFAULT_PTGEN_PROVIDERS,
+    PTGenProviderError,
+    StaticPtGenProvider,
+)
+from differential.utils.ptgen.reference import PTGenReference, parse_ptgen_reference
+from differential.utils.ptgen_handler import PTGenHandler, normalize_ptgen_payload
+
+
+class FakeResponse:
+    def __init__(self, data, ok=True, status_code=200, reason="OK"):
+        self._data = data
+        self.ok = ok
+        self.status_code = status_code
+        self.reason = reason
+
+    def json(self):
+        return self._data
+
+
+class InvalidJsonResponse(FakeResponse):
+    def json(self):
+        raise ValueError("bad json")
+
+
+class FakeSession:
+    def __init__(self, data):
+        self.data = data
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return FakeResponse(self.data)
+
+
+class FailingProvider:
+    name = "failing"
+
+    def fetch(self, reference, session, timeout):
+        raise PTGenProviderError("forced failure")
+
+
+class MappingProvider:
+    name = "mapping"
+
+    def __init__(self, payloads):
+        self.payloads = payloads
+        self.references = []
+
+    def fetch(self, reference, session, timeout):
+        self.references.append(reference)
+        key = (reference.site, reference.sid)
+        if key not in self.payloads:
+            raise PTGenProviderError(f"missing {key}")
+        return self.payloads[key]
+
+
+class PTGenProviderTest(unittest.TestCase):
+    def test_reference_parser_supports_archive_sites(self):
+        cases = {
+            "https://movie.douban.com/subject/1292052/": ("douban", "1292052"),
+            "https://movie.douban.com/celebrity/1054521/": ("douban_celebrity", "1054521"),
+            "https://www.douban.com/personage/27205857/": ("douban_personage", "27205857"),
+            "https://www.imdb.com/title/tt0111161/": ("imdb", "tt0111161"),
+            "https://bgm.tv/subject/81582": ("bangumi", "81582"),
+            "https://store.steampowered.com/app/252950/Rocket_League/": ("steam", "252950"),
+            "https://indienova.com/game/my-hidden-things": ("indienova", "my-hidden-things"),
+            "https://www.epicgames.com/store/zh-CN/product/control/home": ("epic", "control"),
+        }
+        for url, expected in cases.items():
+            with self.subTest(url=url):
+                reference = parse_ptgen_reference(url)
+                self.assertIsNotNone(reference)
+                self.assertEqual((reference.site, reference.sid), expected)
+
+    def test_static_provider_builds_archive_url(self):
+        provider = StaticPtGenProvider("static", "https://example.test/ptgen")
+        reference = PTGenReference("douban", "1292052", "")
+        self.assertEqual(
+            provider.url_for(reference),
+            "https://example.test/ptgen/douban/1292052.json",
+        )
+
+    def test_default_provider_order_is_static_static_api(self):
+        self.assertEqual(
+            [provider.name for provider in DEFAULT_PTGEN_PROVIDERS],
+            ["ourhelp-cdn", "github-pages", "ourhelp-api"],
+        )
+        self.assertEqual(
+            DEFAULT_PTGEN_PROVIDERS[0].base_url,
+            "https://cdn.ourhelp.club/ptgen",
+        )
+        self.assertEqual(
+            DEFAULT_PTGEN_PROVIDERS[1].base_url,
+            "https://ourbits.github.io/PtGen",
+        )
+        self.assertEqual(
+            DEFAULT_PTGEN_PROVIDERS[2].base_url,
+            "https://api.ourhelp.club/infogen",
+        )
+
+    def test_api_provider_sends_site_and_sid(self):
+        provider = ApiPtGenProvider("api", "https://example.test/infogen")
+        session = FakeSession({"site": "imdb", "sid": "tt0111161"})
+        reference = PTGenReference("imdb", "tt0111161", "")
+
+        provider.fetch(reference, session, 5)
+
+        self.assertEqual(session.calls[0][0], "https://example.test/infogen")
+        self.assertEqual(
+            session.calls[0][1]["params"],
+            {"site": "imdb", "sid": "tt0111161"},
+        )
+
+    def test_normalize_static_payload_sets_success_and_format(self):
+        reference = PTGenReference("imdb", "tt0111161", "")
+        payload = normalize_ptgen_payload(
+            {
+                "site": "imdb",
+                "sid": "tt0111161",
+                "name": "The Shawshank Redemption",
+                "description": "A banker keeps hope alive.",
+            },
+            reference,
+        )
+
+        self.assertTrue(payload["success"])
+        self.assertIn("Title: The Shawshank Redemption", payload["format"])
+        self.assertIn("Introduction", payload["format"])
+
+    def test_normalize_preserves_api_format(self):
+        reference = PTGenReference("douban", "1292052", "")
+        payload = normalize_ptgen_payload(
+            {
+                "site": "douban",
+                "sid": "1292052",
+                "success": True,
+                "format": "remote format",
+            },
+            reference,
+        )
+        self.assertEqual(payload["format"], "remote format")
+
+    def test_normalize_rejects_provider_failures(self):
+        reference = PTGenReference("imdb", "tt0111161", "")
+        with self.assertRaises(PTGenProviderError):
+            normalize_ptgen_payload(
+                {"site": "douban", "sid": "1292052"},
+                reference,
+            )
+        with self.assertRaises(PTGenProviderError):
+            normalize_ptgen_payload(
+                {"site": "imdb", "sid": "tt0111161", "success": False, "error": "nope"},
+                reference,
+            )
+
+    def test_provider_rejects_invalid_and_non_object_json(self):
+        provider = StaticPtGenProvider("static", "https://example.test/ptgen")
+        reference = PTGenReference("imdb", "tt0111161", "")
+
+        invalid_session = FakeSession({})
+        invalid_session.get = lambda *args, **kwargs: InvalidJsonResponse({})
+        with self.assertRaises(PTGenProviderError):
+            provider.fetch(reference, invalid_session, 5)
+
+        non_object_session = FakeSession(["not", "object"])
+        with self.assertRaises(PTGenProviderError):
+            provider.fetch(reference, non_object_session, 5)
+
+    def test_handler_falls_back_to_next_provider(self):
+        provider = MappingProvider(
+            {
+                ("imdb", "tt0111161"): {
+                    "site": "imdb",
+                    "sid": "tt0111161",
+                    "name": "The Shawshank Redemption",
+                    "description": "A banker keeps hope alive.",
+                }
+            }
+        )
+        handler = PTGenHandler(
+            "https://www.imdb.com/title/tt0111161/",
+            providers=[FailingProvider(), provider],
+        )
+
+        ptgen, douban, imdb = handler.fetch_ptgen_info()
+
+        self.assertIsInstance(ptgen, IMDBData)
+        self.assertIsNone(douban)
+        self.assertIsInstance(imdb, IMDBData)
+        self.assertEqual(provider.references[0].site, "imdb")
+
+    def test_handler_supports_api_only_douban_personage_after_static_failures(self):
+        provider = MappingProvider(
+            {
+                ("douban_personage", "27205857"): {
+                    "site": "douban_personage",
+                    "sid": "27205857",
+                    "name": "Personage",
+                    "introduction": "Biography",
+                }
+            }
+        )
+        handler = PTGenHandler(
+            "https://www.douban.com/personage/27205857/",
+            providers=[FailingProvider(), FailingProvider(), provider],
+        )
+
+        ptgen, douban, imdb = handler.fetch_ptgen_info()
+
+        self.assertTrue(ptgen.success)
+        self.assertEqual(ptgen.site, "douban_personage")
+        self.assertIn("Personage", ptgen.format)
+        self.assertIsNone(douban)
+        self.assertIsNone(imdb)
+
+    def test_handler_fetches_imdb_for_douban_payload(self):
+        provider = MappingProvider(
+            {
+                ("douban", "1292052"): {
+                    "site": "douban",
+                    "sid": "1292052",
+                    "chinese_title": "肖申克的救赎",
+                    "foreign_title": "The Shawshank Redemption",
+                    "imdb_link": "https://www.imdb.com/title/tt0111161/",
+                },
+                ("imdb", "tt0111161"): {
+                    "site": "imdb",
+                    "sid": "tt0111161",
+                    "name": "The Shawshank Redemption",
+                },
+            }
+        )
+        handler = PTGenHandler(
+            "https://movie.douban.com/subject/1292052/",
+            providers=[provider],
+        )
+
+        ptgen, douban, imdb = handler.fetch_ptgen_info()
+
+        self.assertIsInstance(ptgen, DoubanData)
+        self.assertIsInstance(douban, DoubanData)
+        self.assertIsInstance(imdb, IMDBData)
+        self.assertEqual(
+            [(ref.site, ref.sid) for ref in provider.references],
+            [("douban", "1292052"), ("imdb", "tt0111161")],
+        )
+
+    def test_format_builder_has_output_for_each_supported_static_site(self):
+        payloads = [
+            {"site": "douban", "sid": "1292052", "chinese_title": "肖申克的救赎", "introduction": "简介"},
+            {"site": "imdb", "sid": "tt0111161", "name": "The Shawshank Redemption", "description": "Intro"},
+            {
+                "site": "steam",
+                "sid": "252950",
+                "cover": "https://example.test/steam.jpg",
+                "name": "Rocket League",
+                "name_chs": "火箭联盟",
+                "detail": "名称: Rocket League\n类型: 动作",
+                "review": ["最近评测: 好评"],
+                "descr": "Game intro",
+                "sysreq": ["Windows\n最低配置:\n内存: 4 GB RAM"],
+            },
+            {
+                "site": "epic",
+                "sid": "control",
+                "logo": "https://example.test/epic.png",
+                "name": "Control",
+                "desc": "![Banner Image] (https://example.test/banner.jpg)\n\nGame intro",
+                "min_req": {"Windows": ["Memory: 8 GB"]},
+            },
+            {
+                "site": "bangumi",
+                "sid": "81582",
+                "cover": "https://example.test/bangumi.jpg",
+                "name": "魔法のプリンセス",
+                "name_cn": "魔法公主明琪桃子",
+                "rating": {"score": 7.8, "total": 21},
+                "staff": [{"key": "导演", "value": "湯山邦彦"}],
+                "cast": [{"name": "ミンキーモモ", "actors": [{"name": "林原めぐみ"}]}],
+                "story": "Story",
+            },
+            {
+                "site": "indienova",
+                "sid": "my-hidden-things",
+                "cover": "https://example.test/indienova.jpg",
+                "chinese_title": "我藏起来的东西",
+                "english_title": "My hidden things",
+                "links": {"Steam": "https://store.steampowered.com/app/1304910/"},
+                "descr": "Game intro",
+            },
+            {
+                "site": "douban_celebrity",
+                "sid": "1054521",
+                "name_full": "Person Name",
+                "birth_date": "1962年1月23日",
+                "roles": ["演员"],
+                "imdb_id": "nm0000001",
+                "introduction": "Bio",
+            },
+            {
+                "site": "douban_personage",
+                "sid": "27205857",
+                "name_full": "Personage Name",
+                "gender": "女",
+                "personage_link": "https://www.douban.com/personage/27205857/",
+                "introduction": "Bio",
+            },
+        ]
+        for payload in payloads:
+            with self.subTest(site=payload["site"]):
+                rendered = build_ptgen_format(payload)
+                self.assertTrue(rendered)
+                self.assertNotIn("None", rendered)
+
+    def test_format_builder_uses_cfworker_style_sections(self):
+        cases = [
+            (
+                "douban",
+                {
+                    "site": "douban",
+                    "sid": "1292052",
+                    "chinese_title": "肖申克的救赎",
+                    "tags": ["剧情", "犯罪"],
+                    "cast": [{"name": "蒂姆·罗宾斯"}, {"name": "摩根·弗里曼"}],
+                    "introduction": "第一行\n第二行",
+                },
+                ["◎标　　签　剧情 | 犯罪", "◎主　　演　蒂姆·罗宾斯", "　　第二行"],
+            ),
+            (
+                "steam",
+                {
+                    "site": "steam",
+                    "sid": "252950",
+                    "steam_id": "252950",
+                    "name_chs": "火箭联盟",
+                    "language": ["英语", "法语"],
+                    "tags": ["多人", "足球"],
+                    "screenshot": ["https://example.test/shot.jpg"],
+                },
+                ["【基本信息】", "游戏语种: 英语 | 法语", "标签: 多人 | 足球", "【游戏截图】"],
+            ),
+            (
+                "bangumi",
+                {
+                    "site": "bangumi",
+                    "sid": "81582",
+                    "story": "Story",
+                    "staff": [{"key": "导演", "value": "湯山邦彦"}],
+                    "cast": [{"name": "ミンキーモモ", "actors": [{"name": "林原めぐみ"}]}],
+                    "alt": "https://bgm.tv/subject/81582",
+                },
+                ["[b]Story: [/b]", "[b]Staff: [/b]", "[b]Cast: [/b]", "(来源于 https://bgm.tv/subject/81582 )"],
+            ),
+            (
+                "indienova",
+                {
+                    "site": "indienova",
+                    "sid": "my-hidden-things",
+                    "chinese_title": "我藏起来的东西",
+                    "links": {"Steam": "https://store.steampowered.com/app/1304910/"},
+                    "price": ["Steam：￥35.00"],
+                    "level": ["https://example.test/rating.png"],
+                },
+                ["中文名称：我藏起来的东西", "[url=https://store.steampowered.com/app/1304910/]Steam[/url]", "价格信息：Steam：￥35.00", "【游戏评级】"],
+            ),
+            (
+                "epic",
+                {
+                    "site": "epic",
+                    "sid": "control",
+                    "logo": "https://example.test/logo.png",
+                    "name": "Control",
+                    "language": ["英语", "法语"],
+                    "min_req": {"Windows": ["Memory: 8 GB"]},
+                    "level": ["https://example.test/rating.png"],
+                },
+                ["游戏名称：Control", "【支持语言】", "Windows\nMemory: 8 GB", "【游戏评级】"],
+            ),
+        ]
+        for site, payload, expected_parts in cases:
+            with self.subTest(site=site):
+                rendered = build_ptgen_format(payload)
+                for expected in expected_parts:
+                    self.assertIn(expected, rendered)
+
+    def test_person_format_includes_person_fields(self):
+        rendered = build_ptgen_format(
+            {
+                "site": "douban_celebrity",
+                "sid": "1105626",
+                "name_full": "彼得·科赫 Peter Koch",
+                "gender": "男",
+                "birth_date": "1962年1月23日",
+                "birth_place": "美国,纽约,纳苏郡",
+                "roles": ["演员"],
+                "imdb_id": "nm0462387",
+                "celebrity_link": "https://movie.douban.com/celebrity/1105626",
+                "personage_link": "https://www.douban.com/personage/27311439/",
+                "introduction": "暂无",
+            }
+        )
+
+        self.assertIn("姓名: 彼得·科赫 Peter Koch", rendered)
+        self.assertIn("出生日期: 1962年1月23日", rendered)
+        self.assertIn("IMDb链接: https://www.imdb.com/name/nm0462387/", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace custom PtGen endpoint fetching with a pluggable PtGen Archive provider chain
- add URL parsing and static/API provider implementations for CDN, GitHub Pages, and Ourhelp API
- build cfworker-style BBCode formats locally for static archive responses while preserving API-provided formats
- remove the old `--ptgen-url` and `--ptgen-retry` options and update docs/config examples
- add focused unit tests for provider fallback, payload normalization, URL parsing, and format rendering

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m unittest discover -s tests`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m compileall -q src/differential tests`
- `git diff --cached --check` before commit

## Notes

The branch was created from `origin/main` so the unrelated local Lsky commit on `main` is not included.