### PR TITLE
Use native BDInfo on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ curl -Lso- https://raw.githubusercontent.com/LeiShi1313/Differential/main/instal
 ```
 
 ### 手动安装
-按照[这个](https://www.mono-project.com/download/stable/#download-lin)页面，安装Mono
-
 ```shell
 # 安装ffmpeg和mediainfo
-sudo apt install ffmpeg mediainfo zlib1g-dev libjpeg-dev
+sudo apt install ffmpeg mediainfo zlib1g-dev libjpeg-dev curl
+
+# 安装原生BDInfoCLI，ARM64请把linux-x64替换为linux-arm64
+curl -L -o /tmp/BDInfo-linux-x64.tar.gz https://github.com/tetrahydroc/BDInfoCLI/releases/download/v1.0.5/BDInfo-linux-x64.tar.gz
+tar -xzf /tmp/BDInfo-linux-x64.tar.gz -C /tmp
+sudo install -m 755 /tmp/BDInfo-linux-x64/BDInfo /usr/local/bin/BDInfo
+
 pip3 install Differential
 ```
 
@@ -42,14 +46,13 @@ pip.exe install Differential
 ```
 
 ## Mac OS
-按照[这个](https://www.mono-project.com/docs/getting-started/install/mac/)页面，安装Mono
-
 ```shell
 # 安装ffmpeg、mediainfo
 brew install ffmpeg mediainfo pipx
 pipx ensurepath
 pipx install Differential
 ```
+原盘BDInfo扫描需要从[BDInfoCLI Releases](https://github.com/tetrahydroc/BDInfoCLI/releases)下载`BDInfo-osx-x64.tar.gz`或`BDInfo-osx-arm64.tar.gz`，并把`BDInfo`放入`PATH`，也可以通过`BDINFOPATH`指定位置。
 
 ## Docker
 
@@ -81,6 +84,7 @@ dft [插件名字] -f [种子文件夹] -u [豆瓣URL]
 - `make_torrent`: 是否制种，默认关闭
 - `geenrate_nfo`: 是否利用mediainfo生成nfo文件，默认关闭
 - `use_short_bdinfo`: 是否使用BDInfo的Quick Summary，默认使用完整的BDInfo
+- 原盘BDInfo扫描：Windows使用内置BDInfo；Linux/Mac优先使用`PATH`或`BDINFOPATH`中的原生`BDInfo`，找不到时回退到Mono运行内置BDInfo
 - `screenshot_count`: 截图生成的张数，默认为0，即不生成截图
 - `image_hosting`: 图床的名称，现在支持ptpimg,chevereto,imgurl和SM.MS
 - `image_hosting_url`: 如果是自建的图床，提供图床链接

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-SUDO=$(if [ $(id -u $whoami) -gt 0 ]; then echo "sudo "; fi)
+SUDO=$(if [ "$(id -u)" -gt 0 ]; then echo "sudo "; fi)
 
 get_distribution() {
 	lsb_dist=""
@@ -24,6 +24,42 @@ reload_path() {
     . "$file"
   fi
 done
+}
+
+BDINFO_VERSION="${BDINFO_VERSION:-1.0.5}"
+
+install_bdinfo() {
+	if command_exists BDInfo; then
+		echo "BDInfo已安装"
+		return
+	fi
+
+	case "$(uname -m)" in
+		x86_64|amd64)
+			bdinfo_runtime="linux-x64"
+			;;
+		aarch64|arm64)
+			bdinfo_runtime="linux-arm64"
+			;;
+		*)
+			echo "当前架构暂未自动安装BDInfo，请从 https://github.com/tetrahydroc/BDInfoCLI/releases 手动安装"
+			return
+			;;
+	esac
+
+	tmp_dir="$(mktemp -d)"
+	bdinfo_url="https://github.com/tetrahydroc/BDInfoCLI/releases/download/v${BDINFO_VERSION}/BDInfo-${bdinfo_runtime}.tar.gz"
+	echo "正在安装BDInfo ${BDINFO_VERSION}..."
+	curl -fsSL "$bdinfo_url" -o "$tmp_dir/BDInfo.tar.gz"
+	tar -xzf "$tmp_dir/BDInfo.tar.gz" -C "$tmp_dir"
+	bdinfo_binary="$(find "$tmp_dir" -type f -name BDInfo | head -n 1)"
+	if [ -z "$bdinfo_binary" ]; then
+		echo "BDInfo安装包中未找到可执行文件"
+		rm -rf "$tmp_dir"
+		exit 1
+	fi
+	$SUDO install -m 755 "$bdinfo_binary" /usr/local/bin/BDInfo
+	rm -rf "$tmp_dir"
 }
 
 do_install() {
@@ -49,7 +85,6 @@ do_install() {
 					dist_version="xenial"
 				;;
 				*)
-					# Mono is not available starting from Ubuntu 22.04
 					dist_version="focal"
 				;;
 			esac
@@ -68,7 +103,6 @@ do_install() {
 					dist_version="jessie"
 				;;
 				*)
-					# Mono is not available starting from Debian 11
 					dist_version="buster"
 				;;
 			esac
@@ -95,17 +129,13 @@ do_install() {
 			echo "正在更新依赖..."
 			export DEBIAN_FRONTEND=noninteractive
 			$SUDO apt-get update -qq >/dev/null
-		    pre_reqs="ffmpeg mediainfo zlib1g-dev libjpeg-dev python3 pipx"
+		    pre_reqs="ffmpeg mediainfo zlib1g-dev libjpeg-dev python3 pipx curl"
 
 			if [ "$lsb_dist" = "ubuntu" ]; then
 				# TODO ubuntu:18.04 Cannot install due to pymediainfo error, might need install newer python
 				TZ=Etc/UTC $SUDO apt-get install -y -qq gnupg ca-certificates apt-utils >/dev/null
-				$SUDO gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-				echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | $SUDO tee /etc/apt/sources.list.d/mono-official-stable.list
 			elif [ "$lsb_dist" = "debian" ] || [ "$lsb_dist" = "raspbian" ]; then
 				$SUDO apt-get install -y -qq apt-transport-https dirmngr gnupg ca-certificates apt-utils >/dev/null
-				$SUDO gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-				echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian stable-buster main" | $SUDO tee /etc/apt/sources.list.d/mono-official-stable.list
 
 				case "$dist_version" in
 				    stretch|jessie)
@@ -128,8 +158,7 @@ do_install() {
 			$SUDO apt-get update -qq >/dev/null && \
 			echo "正在安装依赖..." && \
 			TZ=Etc/UTC $SUDO apt-get install -y -qq $pre_reqs >/dev/null && \
-			echo "正在安装Mono..." && \
-			$SUDO apt-get install -y -qq mono-devel >/dev/null && \
+			install_bdinfo && \
 			echo "正在安装差速器..."
 			$SUDO pipx ensurepath && reload_path
 			pipx install Differential
@@ -138,20 +167,14 @@ do_install() {
 		centos | fedora | rhel)
 			if [ "$lsb_dist" = "fedora" ]; then
 				pkg_manager="dnf"
-				pre_reqs="ffmpeg mediainfo python3 pipx"
+				pre_reqs="ffmpeg mediainfo python3 pipx curl"
 
-				$SUDO rpm --import "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
-				if [[ $dist_version -gt 28 ]]; then
-					$SUDO su -c "curl https://download.mono-project.com/repo/centos8-stable.repo | $SUDO tee /etc/yum.repos.d/mono-centos8-stable.repo"
-				else
-					$SUDO su -c "curl https://download.mono-project.com/repo/centos7-stable.repo | $SUDO tee /etc/yum.repos.d/mono-centos7-stable.repo"
-				fi
 				$SUDO $pkg_manager install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 				$SUDO $pkg_manager config-manager --enable PowerTools && dnf install --nogpgcheck && \
 				$SUDO $pkg_manager install -y https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 			else
 				pkg_manager="yum"
-				pre_reqs="ffmpeg mediainfo python3 pipx zlib-devel libjpeg-devel gcc python3-devel"
+				pre_reqs="ffmpeg mediainfo python3 pipx zlib-devel libjpeg-devel gcc python3-devel curl"
 
 				$SUDO $pkg_manager install -y -qq epel-release
 				case "$dist_version" in
@@ -162,37 +185,33 @@ do_install() {
 						$SUDO dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
 						$SUDO dnf config-manager --set-enabled powertools && \
 						$SUDO dnf -y install mediainfo 2>&1 > /dev/null
-						$SUDO rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
 						$SUDO $pkg_manager install -y https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 						;;
 					7)
 						$SUDO rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
 						$SUDO rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-						$SUDO rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
 						;;
 					6)
 						$SUDO rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
 						$SUDO rpm -Uvh http://li.nux.ro/download/nux/dextop/el6/x86_64/nux-dextop-release-0-2.el6.nux.noarch.rpm
-						$SUDO rpm --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"	
 						;;
 				esac
-				$SUDO su -c "curl https://download.mono-project.com/repo/centos$dist_version-stable.repo | $SUDO tee /etc/yum.repos.d/mono-centos$dist_version-stable.repo"
 			fi
 
 			echo "正在更新安装包..." && \
 			$SUDO $pkg_manager update -y -qq > /dev/null && \
 			echo "正在安装依赖..." && \
 			$SUDO $pkg_manager install -y -qq $pre_reqs > /dev/null && \
-			echo "正在安装Mono..." && \
-			$SUDO $pkg_manager install -y mono-devel && \
+			install_bdinfo && \
 			echo "正在安装差速器..."
 			$SUDO pipx ensurepath && reload_path
 			pipx install Differential
 			;;
 		arch)
 			echo "正在安装依赖..." && \
-			$SUDO pacman -Sy --noconfirm vlc python3 python-pipx mediainfo mono ffmpeg 2>&1 > /dev/null
+			$SUDO pacman -Sy --noconfirm vlc python3 python-pipx mediainfo ffmpeg curl > /dev/null 2>&1
 			# TODO cleanup ffmpeg ?
+			install_bdinfo
 			echo "正在安装差速器..." && \
 			$SUDO pipx ensurepath && reload_path
 			pipx install Differential

--- a/src/differential/utils/mediainfo_handler.py
+++ b/src/differential/utils/mediainfo_handler.py
@@ -4,6 +4,7 @@ import sys
 import platform
 import tempfile
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from loguru import logger
 from typing import Optional, List
@@ -13,6 +14,59 @@ from differential import tools
 from differential.version import version
 from differential.utils.binary import execute_with_output
 from differential.utils.mediainfo import get_full_mediainfo, get_duration, get_resolution
+
+
+BDINFO_ENV_VAR = "BDINFOPATH"
+BDINFO_BINARY_NAMES = ("BDInfo", "bdinfo")
+
+
+def _escape_shell_path(path) -> str:
+    return str(path).replace('"', '\\"')
+
+
+def _bundled_bdinfo_path() -> Path:
+    return Path(tools.__file__).resolve().parent / "BDinfoCli.0.7.3" / "BDInfo.exe"
+
+
+def find_native_bdinfo() -> Optional[Path]:
+    env_path = os.environ.get(BDINFO_ENV_VAR)
+    if env_path:
+        candidate = Path(env_path)
+        if candidate.is_file():
+            return candidate
+        logger.error(f"{candidate}不是可执行文件！")
+        sys.exit(1)
+
+    for name in BDINFO_BINARY_NAMES:
+        cwd_candidate = Path.cwd().joinpath(name)
+        if cwd_candidate.is_file():
+            return cwd_candidate
+
+        which_candidate = shutil.which(name)
+        if which_candidate:
+            return Path(which_candidate)
+
+    return None
+
+
+@dataclass(frozen=True)
+class BDInfoRunner:
+    name: str
+    executable: str
+    use_mono: bool = False
+
+    def run(self, bd_path: Path, report_dir: str) -> None:
+        bd_path_arg = _escape_shell_path(bd_path)
+        report_dir_arg = _escape_shell_path(report_dir)
+
+        if self.use_mono:
+            executable_arg = _escape_shell_path(self.executable)
+            args = f'"{executable_arg}" -w "{bd_path_arg}" "{report_dir_arg}"'
+            execute_with_output("mono", args, abort=True)
+            return
+
+        args = f'-w "{bd_path_arg}" "{report_dir_arg}"'
+        execute_with_output(self.executable, args, abort=True)
 
 
 class MediaInfoHandler:
@@ -153,17 +207,24 @@ class MediaInfoHandler:
         return None
 
     def _run_bdinfo_scan(self, temp_dir: str) -> None:
-        bdinfo_exe = os.path.join(os.path.dirname(tools.__file__), "BDinfoCli.0.7.3", "BDInfo.exe")
+        runner = self._select_bdinfo_runner()
         for bdmv_path in self.folder.glob("**/BDMV"):
             logger.info(f"[BDInfo] 扫描: {bdmv_path.parent}")
-            if platform.system() == "Windows":
-                # path = bdmv_path.parent.replace('"', '\\"')
-                args = f'-w "{bdmv_path.parent}" "{temp_dir}"'
-                execute_with_output(bdinfo_exe, args, abort=True)
-            else:
-                path = bdmv_path.parent.replace('"', '\\"')
-                args = f'"{bdinfo_exe}" -w "{path}" "{temp_dir}"'
-                execute_with_output("mono", args, abort=True)
+            runner.run(bdmv_path.parent, temp_dir)
+
+    def _select_bdinfo_runner(self) -> BDInfoRunner:
+        bundled_bdinfo = _bundled_bdinfo_path()
+        if platform.system() == "Windows":
+            logger.info(f"[BDInfo] 使用内置BDInfo: {bundled_bdinfo}")
+            return BDInfoRunner("bundled", str(bundled_bdinfo))
+
+        native_bdinfo = find_native_bdinfo()
+        if native_bdinfo:
+            logger.info(f"[BDInfo] 使用原生BDInfo: {native_bdinfo}")
+            return BDInfoRunner("native", str(native_bdinfo))
+
+        logger.info("[BDInfo] 未找到原生BDInfo，回退到Mono运行内置BDInfo")
+        return BDInfoRunner("mono", str(bundled_bdinfo), use_mono=True)
 
     def _collect_bdinfo_from_temp(self, temp_dir: str) -> str:
         txt_files = sorted(Path(temp_dir).glob("*.txt"))

--- a/tests/test_bdinfo_runner.py
+++ b/tests/test_bdinfo_runner.py
@@ -1,0 +1,102 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from differential.utils import mediainfo_handler
+from differential.utils.mediainfo_handler import (
+    BDINFO_ENV_VAR,
+    BDInfoRunner,
+    MediaInfoHandler,
+    find_native_bdinfo,
+)
+
+
+class BDInfoRunnerTest(unittest.TestCase):
+    def test_native_runner_invokes_bdinfo_directly(self):
+        runner = BDInfoRunner("native", "/usr/local/bin/BDInfo")
+
+        with patch.object(mediainfo_handler, "execute_with_output") as execute:
+            runner.run(Path("/media/Some Disc"), "/tmp/report dir")
+
+        execute.assert_called_once_with(
+            "/usr/local/bin/BDInfo",
+            '-w "/media/Some Disc" "/tmp/report dir"',
+            abort=True,
+        )
+
+    def test_mono_runner_wraps_bundled_bdinfo(self):
+        runner = BDInfoRunner("mono", "/opt/tools/BDInfo.exe", use_mono=True)
+
+        with patch.object(mediainfo_handler, "execute_with_output") as execute:
+            runner.run(Path("/media/Some Disc"), "/tmp/report dir")
+
+        execute.assert_called_once_with(
+            "mono",
+            '"/opt/tools/BDInfo.exe" -w "/media/Some Disc" "/tmp/report dir"',
+            abort=True,
+        )
+
+    def test_find_native_bdinfo_uses_bdinfopath(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bdinfo = Path(temp_dir).joinpath("BDInfo")
+            bdinfo.touch()
+
+            with patch.dict(os.environ, {BDINFO_ENV_VAR: str(bdinfo)}, clear=True):
+                self.assertEqual(find_native_bdinfo(), bdinfo)
+
+    def test_find_native_bdinfo_uses_path(self):
+        def fake_which(name):
+            if name == "BDInfo":
+                return "/usr/bin/BDInfo"
+            return None
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(mediainfo_handler.shutil, "which", side_effect=fake_which):
+                self.assertEqual(find_native_bdinfo(), Path("/usr/bin/BDInfo"))
+
+    def test_windows_uses_bundled_bdinfo(self):
+        handler = MediaInfoHandler(Path("/media/Some Disc"), False, False, True)
+
+        with patch.object(mediainfo_handler.platform, "system", return_value="Windows"):
+            with patch.object(mediainfo_handler, "_bundled_bdinfo_path", return_value=Path("/tools/BDInfo.exe")):
+                with patch.object(mediainfo_handler, "find_native_bdinfo") as find_native:
+                    runner = handler._select_bdinfo_runner()
+
+        self.assertEqual(runner.name, "bundled")
+        self.assertEqual(runner.executable, "/tools/BDInfo.exe")
+        self.assertFalse(runner.use_mono)
+        find_native.assert_not_called()
+
+    def test_linux_prefers_native_bdinfo(self):
+        handler = MediaInfoHandler(Path("/media/Some Disc"), False, False, True)
+
+        with patch.object(mediainfo_handler.platform, "system", return_value="Linux"):
+            with patch.object(mediainfo_handler, "find_native_bdinfo", return_value=Path("/usr/bin/BDInfo")):
+                runner = handler._select_bdinfo_runner()
+
+        self.assertEqual(runner.name, "native")
+        self.assertEqual(runner.executable, "/usr/bin/BDInfo")
+        self.assertFalse(runner.use_mono)
+
+    def test_linux_falls_back_to_mono_when_native_missing(self):
+        handler = MediaInfoHandler(Path("/media/Some Disc"), False, False, True)
+
+        with patch.object(mediainfo_handler.platform, "system", return_value="Linux"):
+            with patch.object(mediainfo_handler, "find_native_bdinfo", return_value=None):
+                with patch.object(mediainfo_handler, "_bundled_bdinfo_path", return_value=Path("/tools/BDInfo.exe")):
+                    runner = handler._select_bdinfo_runner()
+
+        self.assertEqual(runner.name, "mono")
+        self.assertEqual(runner.executable, "/tools/BDInfo.exe")
+        self.assertTrue(runner.use_mono)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Prefer native `BDInfo` on Linux/macOS via `BDINFOPATH`, current working directory, or `PATH`.
- Keep Windows on the bundled `BDInfo.exe` and keep Mono as a fallback only when native `BDInfo` is unavailable.
- Update Linux/macOS install docs and the Linux installer to use tetrahydroc/BDInfoCLI native release assets instead of installing Mono by default.
- Add focused unit tests for native, Mono fallback, and Windows runner selection.

## Validation

- `/home/lei/workspace/created/Differential/.venv/bin/python -m unittest discover -s tests` passed: 21 tests.
- `/home/lei/workspace/created/Differential/.venv/bin/python -m compileall -q src/differential tests` passed. Existing syntax warnings were emitted from older files during an earlier compile run.
- `git diff --check` passed.
- Real BDMV full report comparisons on `/mnt/fnos/Downloads/`:
  - `The.Last.Of.Sheila.1973.MULTi.COMPLETE.BLURAY-MONUMENT`: native and Mono both generated reports with `DISC INFO` and `QUICK SUMMARY`; handler extraction returned non-empty full and quick output for both.
  - `The.Negotiator.1998.Blu-ray.x264.DTS.2Audios.MiniBD1080P-CMCT`: native rc=0, Mono rc=0, both generated one report, matching disc size `15,143,184,364 bytes`.
  - `Love.Go.Go.1997.JAPANESE.COMPLETE.BLURAY-NOELLE`: native rc=0, Mono rc=0, both generated one report, matching disc size `19,086,142,434 bytes`.
- Real BDMV `--list` probes for paths with non-ASCII/spaces:
  - `爱丽丝的失踪.The.Disappearance.of.Alice.Creed.2009...`: native rc=0, Mono rc=0.
  - `Los Versos del Olvido 2017...`: native rc=0, Mono rc=0.

## Notes

`shellcheck install.sh` still reports pre-existing warnings around sourced OS files, package-list word splitting, and old redirect order. I fixed the warnings in lines touched by this PR but did not broaden the change into a full installer cleanup.
