### PR TITLE
Support Linux ISO auto-mounting

### DIFF
--- a/src/differential/base_plugin.py
+++ b/src/differential/base_plugin.py
@@ -412,34 +412,37 @@ class Base(ABC, TorrnetBase, metaclass=PluginRegister):
         self.imdb: Optional[IMDBData] = None
 
     def upload(self):
-        self._prepare()
-        if self.easy_upload:
-            torrent_info = self.easy_upload_torrent_info
-            if self.trim_description:
-                # 直接打印简介部分来绕过浏览器的链接长度限制
-                torrent_info["description"] = ""
-            logger.trace(f"torrent_info: {torrent_info}")
-            link = f"{self.upload_url}#torrentInfo={quote(json.dumps(torrent_info))}"
-            logger.trace(f"已生成自动上传链接：{link}")
-            if self.trim_description:
-                logger.info(f"种子描述：\n{self.description}")
-            open_link(link, self.use_short_url)
-        elif self.auto_feed:
-            link = f"{self.upload_url}#{self.auto_feed_info}"
-            # if self.trim_description:
-            #     logger.info(f"种子描述：\n{self.description}")
-            logger.trace(f"已生成自动上传链接：{link}")
-            open_link(link, self.use_short_url)
-        else:
-            logger.info(
-                "\n"
-                f"标题: {self.title}\n"
-                f"副标题: {self.subtitle}\n"
-                f"豆瓣: {self.douban_url}\n"
-                f"IMDB: {self.imdb_url}\n"
-                f"视频编码: {self.video_codec} 音频编码: {self.audio_codec} 分辨率: {self.resolution}\n"
-                f"描述:\n{self.description}"
-            )
+        try:
+            self._prepare()
+            if self.easy_upload:
+                torrent_info = self.easy_upload_torrent_info
+                if self.trim_description:
+                    # 直接打印简介部分来绕过浏览器的链接长度限制
+                    torrent_info["description"] = ""
+                logger.trace(f"torrent_info: {torrent_info}")
+                link = f"{self.upload_url}#torrentInfo={quote(json.dumps(torrent_info))}"
+                logger.trace(f"已生成自动上传链接：{link}")
+                if self.trim_description:
+                    logger.info(f"种子描述：\n{self.description}")
+                open_link(link, self.use_short_url)
+            elif self.auto_feed:
+                link = f"{self.upload_url}#{self.auto_feed_info}"
+                # if self.trim_description:
+                #     logger.info(f"种子描述：\n{self.description}")
+                logger.trace(f"已生成自动上传链接：{link}")
+                open_link(link, self.use_short_url)
+            else:
+                logger.info(
+                    "\n"
+                    f"标题: {self.title}\n"
+                    f"副标题: {self.subtitle}\n"
+                    f"豆瓣: {self.douban_url}\n"
+                    f"IMDB: {self.imdb_url}\n"
+                    f"视频编码: {self.video_codec} 音频编码: {self.audio_codec} 分辨率: {self.resolution}\n"
+                    f"描述:\n{self.description}"
+                )
+        finally:
+            self.mediainfo_handler.cleanup()
 
     def _prepare(self):
         self.main_file = self.mediainfo_handler.find_mediainfo()

--- a/src/differential/utils/binary.py
+++ b/src/differential/utils/binary.py
@@ -56,26 +56,26 @@ def build_cmd(binary_name: str, args: str, abort: bool = False) -> str:
 
 def execute_with_output(binary_name: str, args: str, abort: bool = False) -> int:
     cmd = build_cmd(binary_name, args, abort)
-    return_code = 0
+    if not cmd:
+        return 1
 
-    def _execute():
-        proc = subprocess.Popen(cmd, shell=True, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                     universal_newlines=True)
-        for stdout in iter(proc.stdout.readline, ""):
-            yield stdout
-        proc.stdout.close()
-        return_code = proc.wait()
+    proc = subprocess.Popen(cmd, shell=True, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                 universal_newlines=True)
     prev = ''
-    for out in iter(_execute()):
+    for out in iter(proc.stdout.readline, ""):
         out = out.strip()
-        if re.sub('(\d| )', '', out) != re.sub('(\d| )', '', prev):
+        if re.sub(r'(\d| )', '', out) != re.sub(r'(\d| )', '', prev):
             print(out)
         else:
             print(out, end='\r')
         sys.stdout.flush()
         prev = out
+    proc.stdout.close()
+    return_code = proc.wait()
     if return_code != 0:
         logger.warning(f"{binary_name} exit with return code {return_code}")
+        if abort:
+            sys.exit(return_code)
     return return_code
     
 

--- a/src/differential/utils/mediainfo_handler.py
+++ b/src/differential/utils/mediainfo_handler.py
@@ -1,9 +1,11 @@
+import glob
 import os
 import re
 import sys
 import platform
 import tempfile
 import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from loguru import logger
@@ -14,6 +16,7 @@ from differential import tools
 from differential.version import version
 from differential.utils.binary import execute_with_output
 from differential.utils.mediainfo import get_full_mediainfo, get_duration, get_resolution
+from differential.utils.privilege import run_with_sudo_fallback
 
 
 BDINFO_ENV_VAR = "BDINFOPATH"
@@ -84,13 +87,18 @@ class MediaInfoHandler:
         scan_bdinfo: bool,
     ):
         self.folder = folder
+        self.original_folder = folder
         self.create_folder = create_folder
         self.use_short_bdinfo = use_short_bdinfo
         self.scan_bdinfo = scan_bdinfo
+        self.media_name = self._media_name(folder)
+        self.cache_key = self._sanitize_name(self.media_name)
 
         self.is_bdmv = False
         self.bdinfo = None
         self.main_file = None
+        self.iso_mount_dir: Optional[Path] = None
+        self.iso_mount_parent: Optional[Path] = None
 
     def find_mediainfo(self):
         """
@@ -103,6 +111,9 @@ class MediaInfoHandler:
         Returns (MediaInfo, BDInfo, main_file, is_bdmv).
         """
         logger.info(f"正在获取Mediainfo: {self.folder}")
+        if self.folder.is_file() and self.folder.suffix.lower() == ".iso":
+            self._mount_iso()
+
         self._handle_single_or_folder()
         if not self.main_file:
             logger.error("未找到可分析的文件，请确认路径。")
@@ -124,6 +135,71 @@ class MediaInfoHandler:
                 self.bdinfo = "[BDINFO HERE]"
 
         return self.main_file
+
+    def cleanup(self) -> None:
+        if not self.iso_mount_dir:
+            return
+
+        if self._is_mountpoint(self.iso_mount_dir):
+            run_with_sudo_fallback(
+                ["umount", "--", str(self.iso_mount_dir)],
+                action=f"卸载ISO: {self.iso_mount_dir}",
+                abort=False,
+            )
+
+        if self._is_mountpoint(self.iso_mount_dir):
+            logger.warning(f"[ISO] 未能卸载挂载点，请手动检查: {self.iso_mount_dir}")
+            return
+
+        for path in (self.iso_mount_dir, self.iso_mount_parent):
+            if path and path.exists():
+                try:
+                    path.rmdir()
+                except OSError as e:
+                    logger.warning(f"[ISO] 清理临时目录失败: {path}: {e}")
+
+        self.iso_mount_dir = None
+        self.iso_mount_parent = None
+
+    @staticmethod
+    def _media_name(folder: Path) -> str:
+        return folder.stem if folder.is_file() else folder.name
+
+    @staticmethod
+    def _sanitize_name(name: str) -> str:
+        sanitized = re.sub(r"[^\w .@+-]+", "_", name, flags=re.UNICODE).strip(" ._")
+        sanitized = re.sub(r"_+", "_", sanitized)
+        return sanitized[:120] or "media"
+
+    @staticmethod
+    def _is_mountpoint(path: Path) -> bool:
+        if shutil.which("mountpoint"):
+            return subprocess.run(["mountpoint", "-q", str(path)]).returncode == 0
+        if shutil.which("findmnt"):
+            return subprocess.run(
+                ["findmnt", "-rn", "--mountpoint", str(path)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode == 0
+        return False
+
+    def _mount_iso(self) -> None:
+        if platform.system() != "Linux":
+            logger.error("请先挂载ISO文件再使用。")
+            sys.exit(1)
+
+        self.iso_mount_parent = Path(tempfile.mkdtemp(prefix=f"Differential.iso.{version}."))
+        self.iso_mount_dir = self.iso_mount_parent.joinpath(self.cache_key)
+        self.iso_mount_dir.mkdir()
+
+        logger.info(f"[ISO] 正在挂载ISO: {self.original_folder}")
+        run_with_sudo_fallback(
+            ["mount", "-o", "ro,loop", "--", str(self.original_folder.resolve()), str(self.iso_mount_dir)],
+            action=f"挂载ISO: {self.original_folder}",
+            abort=True,
+        )
+        self.folder = self.iso_mount_dir
+        logger.info(f"[ISO] 已挂载到: {self.folder}")
 
     @property
     def media_info(self):
@@ -192,15 +268,16 @@ class MediaInfoHandler:
             return cached
 
         # Otherwise, run BDInfo scanning
-        temp_dir = tempfile.mkdtemp(prefix=f"Differential.bdinfo.{version}.", suffix=f".{self.folder.name}")
+        temp_dir = tempfile.mkdtemp(prefix=f"Differential.bdinfo.{version}.", suffix=f".{self.cache_key}")
         self._run_bdinfo_scan(temp_dir)
         return self._collect_bdinfo_from_temp(temp_dir)
 
     def _find_cached_bdinfo(self) -> Optional[str]:
         """
-        Look in the temp dir for an existing BDInfo scan matching self.folder.name.
+        Look in the temp dir for an existing BDInfo scan matching this media.
         """
-        for d in Path(tempfile.gettempdir()).glob(f"Differential.bdinfo.{version}.*.{self.folder.name}"):
+        pattern = f"Differential.bdinfo.{glob.escape(version)}.*.{glob.escape(self.cache_key)}"
+        for d in (Path(p) for p in glob.glob(str(Path(tempfile.gettempdir()).joinpath(pattern)))):
             if d.is_dir():
                 if txt_files := list(d.glob("*.txt")):
                     return self._extract_bdinfo_content(txt_files)
@@ -239,7 +316,7 @@ class MediaInfoHandler:
             content = txt.read_text(errors="ignore")
             if self.use_short_bdinfo:
                 # Extract QUICK SUMMARY
-                if m := re.search(r"(QUICK SUMMARY:\n+(.+?\n)+)\n\n", content):
+                if m := re.search(r"(QUICK SUMMARY:\r?\n+(?:[^\r\n].*(?:\r?\n|$))+)", content):
                     bdinfos.append(m.group(1))
             else:
                 # Extract DISC INFO

--- a/src/differential/utils/privilege.py
+++ b/src/differential/utils/privilege.py
@@ -1,0 +1,79 @@
+import shutil
+import subprocess
+import sys
+from typing import List
+
+from loguru import logger
+
+
+def _run(cmd: List[str], *, capture: bool) -> subprocess.CompletedProcess:
+    logger.trace(" ".join(cmd))
+    try:
+        if capture:
+            return subprocess.run(cmd, text=True, capture_output=True)
+        return subprocess.run(cmd)
+    except FileNotFoundError as e:
+        return subprocess.CompletedProcess(cmd, 127, stderr=str(e))
+
+
+def _sudo_auth_required(proc: subprocess.CompletedProcess) -> bool:
+    stderr = (proc.stderr or "").lower()
+    auth_markers = (
+        "a password is required",
+        "password is required",
+        "a terminal is required to read the password",
+        "no tty present",
+    )
+    denial_markers = (
+        "not in the sudoers file",
+        "may not run sudo",
+        "is not allowed to run sudo",
+        "permission denied",
+    )
+    return any(marker in stderr for marker in auth_markers) and not any(
+        marker in stderr for marker in denial_markers
+    )
+
+
+def _log_failure(action: str, proc: subprocess.CompletedProcess) -> None:
+    stderr = (proc.stderr or "").strip()
+    stdout = (proc.stdout or "").strip()
+    details = "\n".join(part for part in (stdout, stderr) if part)
+    logger.warning(f"{action}失败，退出码：{proc.returncode}" + (f"\n{details}" if details else ""))
+
+
+def _finish(action: str, proc: subprocess.CompletedProcess, abort: bool) -> subprocess.CompletedProcess:
+    if proc.returncode != 0:
+        _log_failure(action, proc)
+        if abort:
+            sys.exit(proc.returncode)
+    return proc
+
+
+def run_with_sudo_fallback(
+    cmd: List[str],
+    *,
+    action: str,
+    abort: bool = True,
+) -> subprocess.CompletedProcess:
+    proc = _run(cmd, capture=True)
+    if proc.returncode == 0:
+        return proc
+
+    if shutil.which("sudo") is None:
+        logger.error(f"{action}需要 sudo 权限，但未找到 sudo。")
+        return _finish(action, proc, abort)
+
+    sudo_proc = _run(["sudo", "-n", *cmd], capture=True)
+    if sudo_proc.returncode == 0:
+        return sudo_proc
+
+    if not _sudo_auth_required(sudo_proc):
+        return _finish(action, sudo_proc, abort)
+
+    if not (sys.stdin.isatty() and sys.stdout.isatty() and sys.stderr.isatty()):
+        logger.error(f"{action}需要 sudo 权限，但当前环境无法交互式输入密码。请先手动挂载，或配置 sudo 权限。")
+        return _finish(action, sudo_proc, abort)
+
+    logger.info(f"{action}需要 sudo 权限，系统可能会提示输入密码...")
+    return _finish(action, _run(["sudo", *cmd], capture=False), abort)

--- a/tests/test_iso_mount.py
+++ b/tests/test_iso_mount.py
@@ -1,0 +1,268 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from differential.base_plugin import Base
+from differential.utils.mediainfo_handler import MediaInfoHandler
+from differential.utils.privilege import run_with_sudo_fallback
+from differential.version import version
+
+
+def completed(cmd, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+class PrivilegeHelperTest(unittest.TestCase):
+    def test_run_with_sudo_fallback_uses_direct_success(self):
+        with mock.patch("subprocess.run", return_value=completed(["mount"])) as run:
+            proc = run_with_sudo_fallback(["mount"], action="mount test")
+
+        self.assertEqual(proc.returncode, 0)
+        run.assert_called_once_with(["mount"], text=True, capture_output=True)
+
+    def test_run_with_sudo_fallback_uses_noninteractive_sudo(self):
+        with mock.patch("shutil.which", return_value="/usr/bin/sudo"), mock.patch(
+            "subprocess.run",
+            side_effect=[
+                completed(["mount"], returncode=1, stderr="permission denied"),
+                completed(["sudo", "-n", "mount"]),
+            ],
+        ) as run:
+            proc = run_with_sudo_fallback(["mount"], action="mount test")
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(run.call_args_list[1].args[0], ["sudo", "-n", "mount"])
+
+    def test_run_with_sudo_fallback_does_not_prompt_for_command_failure(self):
+        with mock.patch("shutil.which", return_value="/usr/bin/sudo"), mock.patch(
+            "subprocess.run",
+            side_effect=[
+                completed(["mount"], returncode=1, stderr="permission denied"),
+                completed(["sudo", "-n", "mount"], returncode=32, stderr="wrong fs type"),
+            ],
+        ) as run:
+            proc = run_with_sudo_fallback(["mount"], action="mount test", abort=False)
+
+        self.assertEqual(proc.returncode, 32)
+        self.assertEqual(len(run.call_args_list), 2)
+
+    def test_run_with_sudo_fallback_returns_failure_without_tty(self):
+        with mock.patch("shutil.which", return_value="/usr/bin/sudo"), mock.patch(
+            "subprocess.run",
+            side_effect=[
+                completed(["mount"], returncode=1, stderr="permission denied"),
+                completed(["sudo", "-n", "mount"], returncode=1, stderr="sudo: a password is required"),
+            ],
+        ), mock.patch("sys.stdin.isatty", return_value=False), mock.patch(
+            "sys.stdout.isatty", return_value=False
+        ), mock.patch("sys.stderr.isatty", return_value=False):
+            proc = run_with_sudo_fallback(["mount"], action="mount test", abort=False)
+
+        self.assertEqual(proc.returncode, 1)
+
+
+class MediaInfoIsoMountTest(unittest.TestCase):
+    def test_find_mediainfo_mounts_linux_iso_before_discovery(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            iso = root / "Movie [Test].iso"
+            iso.write_bytes(b"iso")
+            mounted = root / "mounted"
+            (mounted / "BDMV" / "STREAM").mkdir(parents=True)
+            (mounted / "BDMV" / "index.bdmv").write_bytes(b"bdmv")
+            main_stream = mounted / "BDMV" / "STREAM" / "00001.m2ts"
+            main_stream.write_bytes(b"stream-data")
+
+            handler = MediaInfoHandler(
+                folder=iso,
+                create_folder=True,
+                use_short_bdinfo=False,
+                scan_bdinfo=False,
+            )
+
+            def fake_mount():
+                handler.iso_mount_parent = root
+                handler.iso_mount_dir = mounted
+                handler.folder = mounted
+
+            with mock.patch.object(handler, "_mount_iso", side_effect=fake_mount) as mount_iso, mock.patch(
+                "differential.utils.mediainfo_handler.platform.system", return_value="Linux"
+            ), mock.patch(
+                "differential.utils.mediainfo_handler.MediaInfo.parse",
+                return_value=SimpleNamespace(to_data=lambda: {}),
+            ):
+                main_file = handler.find_mediainfo()
+
+            mount_iso.assert_called_once()
+            self.assertEqual(main_file, main_stream)
+            self.assertTrue(iso.exists())
+            self.assertTrue(handler.is_bdmv)
+            self.assertEqual(handler.bdinfo, "[BDINFO HERE]")
+
+    def test_cleanup_unmounts_and_removes_temp_mount_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp) / "iso-parent"
+            mount_dir = parent / "movie"
+            mount_dir.mkdir(parents=True)
+            handler = MediaInfoHandler(mount_dir / "movie.iso", False, False, True)
+            handler.iso_mount_parent = parent
+            handler.iso_mount_dir = mount_dir
+
+            with mock.patch.object(handler, "_is_mountpoint", side_effect=[True, False]), mock.patch(
+                "differential.utils.mediainfo_handler.run_with_sudo_fallback",
+                return_value=completed(["umount"]),
+            ) as sudo:
+                handler.cleanup()
+
+            sudo.assert_called_once_with(
+                ["umount", "--", str(mount_dir)],
+                action=f"卸载ISO: {mount_dir}",
+                abort=False,
+            )
+            self.assertFalse(parent.exists())
+
+    def test_mount_iso_uses_read_only_loop_mount_with_option_terminator(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            iso = root / "-leading-dash.iso"
+            iso.write_bytes(b"iso")
+            mount_parent = root / "mount-parent"
+            mount_parent.mkdir()
+            handler = MediaInfoHandler(iso, False, False, True)
+
+            with mock.patch(
+                "differential.utils.mediainfo_handler.platform.system",
+                return_value="Linux",
+            ), mock.patch(
+                "differential.utils.mediainfo_handler.tempfile.mkdtemp",
+                return_value=str(mount_parent),
+            ), mock.patch(
+                "differential.utils.mediainfo_handler.run_with_sudo_fallback",
+                return_value=completed(["mount"]),
+            ) as sudo:
+                handler._mount_iso()
+
+            expected_mount_dir = mount_parent / handler.cache_key
+            sudo.assert_called_once_with(
+                ["mount", "-o", "ro,loop", "--", str(iso.resolve()), str(expected_mount_dir)],
+                action=f"挂载ISO: {iso}",
+                abort=True,
+            )
+            self.assertEqual(handler.folder, expected_mount_dir)
+
+    def test_mount_iso_exits_on_non_linux(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            iso = Path(tmp) / "Movie.iso"
+            iso.write_bytes(b"iso")
+            handler = MediaInfoHandler(iso, False, False, True)
+
+            with mock.patch(
+                "differential.utils.mediainfo_handler.platform.system",
+                return_value="Darwin",
+            ), self.assertRaises(SystemExit):
+                handler._mount_iso()
+
+            self.assertIsNone(handler.iso_mount_dir)
+
+    def test_bdinfo_cache_uses_sanitized_original_media_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            handler = MediaInfoHandler(Path("Movie [Test]*.iso"), False, False, True)
+            cache_dir = Path(tmp) / f"Differential.bdinfo.{version}.abc.{handler.cache_key}"
+            cache_dir.mkdir()
+            (cache_dir / "BDINFO.txt").write_text("DISC INFO:\n\nName: Test\n\nCHAPTERS:\n", encoding="utf-8")
+
+            with mock.patch("differential.utils.mediainfo_handler.tempfile.gettempdir", return_value=tmp):
+                cached = handler._find_cached_bdinfo()
+
+        self.assertNotIn("[", handler.cache_key)
+        self.assertNotIn("*", handler.cache_key)
+        self.assertIn("DISC INFO", cached)
+
+    def test_short_bdinfo_extracts_quick_summary_at_eof(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = Path(tmp) / "BDINFO.txt"
+            report.write_text(
+                "DISC INFO:\n\nName: Test\n\nQUICK SUMMARY:\n\nDisc Title: Test\nPlaylist: 00001.MPLS\n",
+                encoding="utf-8",
+            )
+            handler = MediaInfoHandler(Path("Movie.iso"), False, True, True)
+
+            bdinfo = handler._extract_bdinfo_content([report])
+
+        self.assertIn("QUICK SUMMARY", bdinfo)
+        self.assertIn("Playlist: 00001.MPLS", bdinfo)
+
+
+class BasePluginIsoWorkflowTest(unittest.TestCase):
+    def test_upload_cleans_up_after_prepare_exception(self):
+        plugin = SimpleNamespace(
+            _prepare=mock.Mock(side_effect=RuntimeError("forced")),
+            mediainfo_handler=SimpleNamespace(cleanup=mock.Mock()),
+        )
+
+        with self.assertRaises(RuntimeError):
+            Base.upload(plugin)
+
+        plugin.mediainfo_handler.cleanup.assert_called_once()
+
+    def test_upload_cleans_up_after_system_exit(self):
+        plugin = SimpleNamespace(
+            _prepare=mock.Mock(side_effect=SystemExit(1)),
+            mediainfo_handler=SimpleNamespace(cleanup=mock.Mock()),
+        )
+
+        with self.assertRaises(SystemExit):
+            Base.upload(plugin)
+
+        plugin.mediainfo_handler.cleanup.assert_called_once()
+
+    def test_prepare_keeps_original_iso_for_nfo_and_torrent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            iso = Path(tmp) / "Movie.iso"
+            iso.write_bytes(b"iso")
+            mounted_stream = Path(tmp) / "mounted" / "BDMV" / "STREAM" / "00001.m2ts"
+            mounted_stream.parent.mkdir(parents=True)
+            mounted_stream.write_bytes(b"stream")
+
+            plugin = SimpleNamespace(
+                folder=iso,
+                announce_url="https://tracker.example/announce",
+                reuse_torrent=True,
+                from_torrent=None,
+                generate_nfo=True,
+                make_torrent=True,
+                mediainfo_handler=SimpleNamespace(
+                    find_mediainfo=mock.Mock(return_value=mounted_stream),
+                    resolution="1080p",
+                    duration=1000,
+                    media_info="media info",
+                    cleanup=mock.Mock(),
+                ),
+                ptgen_handler=SimpleNamespace(fetch_ptgen_info=mock.Mock(return_value=(None, None, None))),
+                screenshot_handler=SimpleNamespace(collect_screenshots=mock.Mock()),
+            )
+
+            with mock.patch("differential.base_plugin.generate_nfo") as generate_nfo, mock.patch(
+                "differential.base_plugin.make_torrent"
+            ) as make_torrent:
+                Base._prepare(plugin)
+
+        plugin.screenshot_handler.collect_screenshots.assert_called_once_with(
+            mounted_stream,
+            "1080p",
+            1000,
+        )
+        generate_nfo.assert_called_once_with(iso, "media info")
+        self.assertEqual(make_torrent.call_args.args[0], iso)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Detect Linux `.iso` inputs, mount them read-only via loop device, and pass the mounted BDMV tree through the existing MediaInfo, screenshot, and BDInfo workflows.
- Add a reusable privileged command helper that tries the direct command, then `sudo -n`, then interactive `sudo` only when sudo reports authentication is required.
- Keep torrent/NFO behavior pointed at the original ISO path while mounted streams are used for analysis.
- Fix streamed command return-code handling so BDInfo failures can abort correctly.
- Add tests for ISO mount lifecycle, sudo fallback behavior, cleanup, cache naming, and split original/mounted path behavior.

## Validation

- `/home/lei/workspace/created/Differential/.venv/bin/python -m unittest discover -s tests` passed: 27 tests.
- `git diff --check` passed.
- Real ISO smoke test with `/mnt/fnos/Downloads/7000077871.iso`: auto-mounted, selected `BDMV/STREAM/00003.m2ts`, produced/reused BDInfo, reported `BDINFO_PRESENT=True`, and cleanup left no mount/temp directory.

## Notes

- The ISO mount layer produces a disc-root directory and remains independent of the BDInfo backend, so a future native Linux BDInfo runner can replace the current Mono path without changing ISO mounting.
