### PR TITLE
Modernize installer distro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## Linux
 
 ### 一键脚本安装
-对于`Debian 9+`/`Ubuntu 20.04+`/`Centos 8`/`Fedora 34+`/`Archlinux`，可以使用一键脚本安装
+对于当前稳定版`Debian`/`Ubuntu`、`Fedora`、`RHEL/CentOS/Rocky/AlmaLinux`以及`Archlinux`，可以使用一键脚本安装。脚本会安装ffmpeg、mediainfo、pipx和原生BDInfoCLI。
 ```shell
 curl -Lso- https://raw.githubusercontent.com/LeiShi1313/Differential/main/install.sh | bash
 ```
@@ -46,13 +46,26 @@ pip.exe install Differential
 ```
 
 ## Mac OS
+
+### 一键脚本安装
+macOS需要先安装[Homebrew](https://brew.sh/)，然后可以使用一键脚本安装。脚本会通过Homebrew安装ffmpeg、mediainfo和pipx，并安装对应CPU架构的原生BDInfoCLI。
 ```shell
-# 安装ffmpeg、mediainfo
+curl -Lso- https://raw.githubusercontent.com/LeiShi1313/Differential/main/install.sh | bash
+```
+
+### 手动安装
+```shell
+# 安装ffmpeg、mediainfo、pipx
 brew install ffmpeg mediainfo pipx
+
+# 安装原生BDInfoCLI，Apple Silicon请把osx-x64替换为osx-arm64
+curl -L -o /tmp/BDInfo-osx-x64.tar.gz https://github.com/tetrahydroc/BDInfoCLI/releases/download/v1.0.5/BDInfo-osx-x64.tar.gz
+tar -xzf /tmp/BDInfo-osx-x64.tar.gz -C /tmp
+sudo install -m 755 /tmp/BDInfo-osx-x64/BDInfo /usr/local/bin/BDInfo
+
 pipx ensurepath
 pipx install Differential
 ```
-原盘BDInfo扫描需要从[BDInfoCLI Releases](https://github.com/tetrahydroc/BDInfoCLI/releases)下载`BDInfo-osx-x64.tar.gz`或`BDInfo-osx-arm64.tar.gz`，并把`BDInfo`放入`PATH`，也可以通过`BDINFOPATH`指定位置。
 
 ## Docker
 

--- a/install.sh
+++ b/install.sh
@@ -1,32 +1,88 @@
 #!/bin/bash
-set -e
-
-SUDO=$(if [ "$(id -u)" -gt 0 ]; then echo "sudo "; fi)
-
-get_distribution() {
-	lsb_dist=""
-	# Every system that we officially support has /etc/os-release
-	if [ -r /etc/os-release ]; then
-		lsb_dist="$(. /etc/os-release && echo "$ID")"
-	fi
-	# Returning an empty string here should be alright since the
-	# case statements don't act unless you provide an actual value
-	echo "$lsb_dist"
-}
-
-command_exists() {
-	command -v "$@" > /dev/null 2>&1
-}
-
-reload_path() {
-  for file in ~/.bashrc ~/.bash_profile ~/.profile; do
-  if [ -f "$file" ]; then
-    . "$file"
-  fi
-done
-}
+set -euo pipefail
 
 BDINFO_VERSION="${BDINFO_VERSION:-1.0.5}"
+DIFFERENTIAL_PACKAGE="${DIFFERENTIAL_PACKAGE:-Differential}"
+DIFFERENTIAL_SKIP_INSTALL="${DIFFERENTIAL_SKIP_INSTALL:-0}"
+
+SUDO=()
+
+command_exists() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+setup_sudo() {
+	if [ "$(id -u)" -eq 0 ]; then
+		return
+	fi
+	if ! command_exists sudo; then
+		echo "当前用户不是root，且未找到sudo，无法安装系统依赖。"
+		exit 1
+	fi
+	SUDO=(sudo)
+}
+
+run_as_root() {
+	"${SUDO[@]}" "$@"
+}
+
+add_pipx_bin_to_path() {
+	local pipx_bin_dir="${PIPX_BIN_DIR:-$HOME/.local/bin}"
+	case ":$PATH:" in
+		*":$pipx_bin_dir:"*) ;;
+		*) PATH="$PATH:$pipx_bin_dir" ;;
+	esac
+	export PATH
+}
+
+pipx_run() {
+	if command_exists pipx; then
+		pipx "$@"
+	else
+		python3 -m pipx "$@"
+	fi
+}
+
+load_os_release() {
+	if [ ! -r /etc/os-release ]; then
+		return 1
+	fi
+
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	DIST_ID="${ID:-}"
+	DIST_ID_LIKE="${ID_LIKE:-}"
+	DIST_VERSION_ID="${VERSION_ID:-}"
+	DIST_PRETTY_NAME="${PRETTY_NAME:-$DIST_ID $DIST_VERSION_ID}"
+}
+
+is_distro_like() {
+	local target="$1"
+	case " $DIST_ID $DIST_ID_LIKE " in
+		*" $target "*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+bdinfo_runtime() {
+	case "$(uname -s):$(uname -m)" in
+		Linux:x86_64|Linux:amd64)
+			echo "linux-x64"
+			;;
+		Linux:aarch64|Linux:arm64)
+			echo "linux-arm64"
+			;;
+		Darwin:x86_64|Darwin:amd64)
+			echo "osx-x64"
+			;;
+		Darwin:aarch64|Darwin:arm64)
+			echo "osx-arm64"
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
 
 install_bdinfo() {
 	if command_exists BDInfo; then
@@ -34,200 +90,196 @@ install_bdinfo() {
 		return
 	fi
 
-	case "$(uname -m)" in
-		x86_64|amd64)
-			bdinfo_runtime="linux-x64"
-			;;
-		aarch64|arm64)
-			bdinfo_runtime="linux-arm64"
-			;;
-		*)
-			echo "当前架构暂未自动安装BDInfo，请从 https://github.com/tetrahydroc/BDInfoCLI/releases 手动安装"
-			return
-			;;
-	esac
+	local runtime
+	if ! runtime="$(bdinfo_runtime)"; then
+		echo "当前系统架构暂未自动安装BDInfo，请从 https://github.com/tetrahydroc/BDInfoCLI/releases 手动安装"
+		return
+	fi
 
+	local tmp_dir
 	tmp_dir="$(mktemp -d)"
-	bdinfo_url="https://github.com/tetrahydroc/BDInfoCLI/releases/download/v${BDINFO_VERSION}/BDInfo-${bdinfo_runtime}.tar.gz"
-	echo "正在安装BDInfo ${BDINFO_VERSION}..."
+	local bdinfo_url="https://github.com/tetrahydroc/BDInfoCLI/releases/download/v${BDINFO_VERSION}/BDInfo-${runtime}.tar.gz"
+
+	echo "正在安装BDInfo ${BDINFO_VERSION} (${runtime})..."
 	curl -fsSL "$bdinfo_url" -o "$tmp_dir/BDInfo.tar.gz"
 	tar -xzf "$tmp_dir/BDInfo.tar.gz" -C "$tmp_dir"
+
+	local bdinfo_binary
 	bdinfo_binary="$(find "$tmp_dir" -type f -name BDInfo | head -n 1)"
 	if [ -z "$bdinfo_binary" ]; then
 		echo "BDInfo安装包中未找到可执行文件"
 		rm -rf "$tmp_dir"
 		exit 1
 	fi
-	$SUDO install -m 755 "$bdinfo_binary" /usr/local/bin/BDInfo
+
+	run_as_root mkdir -p /usr/local/bin
+	run_as_root install -m 755 "$bdinfo_binary" /usr/local/bin/BDInfo
 	rm -rf "$tmp_dir"
 }
 
-do_install() {
-    lsb_dist=$( get_distribution )
-	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+install_differential() {
+	if [ "$DIFFERENTIAL_SKIP_INSTALL" = "1" ]; then
+		echo "已跳过差速器安装"
+		return
+	fi
 
-	case "$lsb_dist" in
-		ubuntu)
-			if command_exists lsb_release; then
-				dist_version="$(lsb_release --codename | cut -f2)"
-			fi
-			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
-				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
-			fi
-			case "$dist_version" in
-				focal)
-					dist_version="focal"
-				;;
-				bionic)
-					dist_version="bionic"
-				;;
-				xenial)
-					dist_version="xenial"
-				;;
-				*)
-					dist_version="focal"
-				;;
-			esac
-		;;
-
-		debian|raspbian)
-			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
-			case "$dist_version" in
-				10)
-					dist_version="buster"
-				;;
-				9)
-					dist_version="stretch"
-				;;
-				8)
-					dist_version="jessie"
-				;;
-				*)
-					dist_version="buster"
-				;;
-			esac
-		;;
-
-		centos|rhel|sles|amzn)
-			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
-				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-			fi
-		;;
-
-		*)
-			if command_exists lsb_release; then
-				dist_version="$(lsb_release --release | cut -f2)"
-			fi
-			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
-				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-			fi
-		;;
-	esac
-
-    case "$lsb_dist" in
-	    ubuntu | debian | raspbian)
-			echo "正在更新依赖..."
-			export DEBIAN_FRONTEND=noninteractive
-			$SUDO apt-get update -qq >/dev/null
-		    pre_reqs="ffmpeg mediainfo zlib1g-dev libjpeg-dev python3 pipx curl"
-
-			if [ "$lsb_dist" = "ubuntu" ]; then
-				# TODO ubuntu:18.04 Cannot install due to pymediainfo error, might need install newer python
-				TZ=Etc/UTC $SUDO apt-get install -y -qq gnupg ca-certificates apt-utils >/dev/null
-			elif [ "$lsb_dist" = "debian" ] || [ "$lsb_dist" = "raspbian" ]; then
-				$SUDO apt-get install -y -qq apt-transport-https dirmngr gnupg ca-certificates apt-utils >/dev/null
-
-				case "$dist_version" in
-				    stretch|jessie)
-						# TODO: Jessie is haveing some SSL issue
-						# might need to install openssl as well
-						# pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
-						echo "正在安装python3.8..."  && \
-						$SUDO apt-get install -y -qq wget build-essential checkinstall libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev && \
-						pushd /tmp && \
-						$SUDO wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz && \
-						$SUDO tar xzf Python-3.8.12.tgz && \
-						cd Python-3.8.12 && \
-						$SUDO ./configure --enable-optimizations > /dev/null && \
-						$SUDO make altinstall
-						;;
-				esac
-			fi
-
-			echo "正在更新安装包..." && \
-			$SUDO apt-get update -qq >/dev/null && \
-			echo "正在安装依赖..." && \
-			TZ=Etc/UTC $SUDO apt-get install -y -qq $pre_reqs >/dev/null && \
-			install_bdinfo && \
-			echo "正在安装差速器..."
-			$SUDO pipx ensurepath && reload_path
-			pipx install Differential
-			;;
-
-		centos | fedora | rhel)
-			if [ "$lsb_dist" = "fedora" ]; then
-				pkg_manager="dnf"
-				pre_reqs="ffmpeg mediainfo python3 pipx curl"
-
-				$SUDO $pkg_manager install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-				$SUDO $pkg_manager config-manager --enable PowerTools && dnf install --nogpgcheck && \
-				$SUDO $pkg_manager install -y https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
-			else
-				pkg_manager="yum"
-				pre_reqs="ffmpeg mediainfo python3 pipx zlib-devel libjpeg-devel gcc python3-devel curl"
-
-				$SUDO $pkg_manager install -y -qq epel-release
-				case "$dist_version" in
-					8)
-						echo "Enabling PowerTools" && \
-						$SUDO dnf -y install dnf-plugins-core 2>&1 > /dev/null && \
-						$SUDO dnf upgrade -y 2>&1 > /dev/null && \
-						$SUDO dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-						$SUDO dnf config-manager --set-enabled powertools && \
-						$SUDO dnf -y install mediainfo 2>&1 > /dev/null
-						$SUDO $pkg_manager install -y https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
-						;;
-					7)
-						$SUDO rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-						$SUDO rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-						;;
-					6)
-						$SUDO rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-						$SUDO rpm -Uvh http://li.nux.ro/download/nux/dextop/el6/x86_64/nux-dextop-release-0-2.el6.nux.noarch.rpm
-						;;
-				esac
-			fi
-
-			echo "正在更新安装包..." && \
-			$SUDO $pkg_manager update -y -qq > /dev/null && \
-			echo "正在安装依赖..." && \
-			$SUDO $pkg_manager install -y -qq $pre_reqs > /dev/null && \
-			install_bdinfo && \
-			echo "正在安装差速器..."
-			$SUDO pipx ensurepath && reload_path
-			pipx install Differential
-			;;
-		arch)
-			echo "正在安装依赖..." && \
-			$SUDO pacman -Sy --noconfirm vlc python3 python-pipx mediainfo ffmpeg curl > /dev/null 2>&1
-			# TODO cleanup ffmpeg ?
-			install_bdinfo
-			echo "正在安装差速器..." && \
-			$SUDO pipx ensurepath && reload_path
-			pipx install Differential
-			;;
-		*)
-			echo "系统版本 $lsb_dist $dist_version 还未支持！"
-			;;
-
-	esac
-
+	add_pipx_bin_to_path
 	if command_exists dft; then
-		dft_version="$(dft -v | awk '{print $2}')"
-		echo "差速器$dft_version安装成功"
-	else
-		echo "差速器安装失败"
+		echo "差速器已安装"
+		return
+	fi
+
+	echo "正在安装差速器..."
+	pipx_run ensurepath >/dev/null || true
+	pipx_run install "$DIFFERENTIAL_PACKAGE"
+	add_pipx_bin_to_path
+}
+
+install_apt_dependencies() {
+	echo "正在安装Debian/Ubuntu依赖..."
+	export DEBIAN_FRONTEND=noninteractive
+	run_as_root apt-get update -qq >/dev/null
+	run_as_root apt-get install -y -qq \
+		ca-certificates \
+		curl \
+		ffmpeg \
+		libicu-dev \
+		libjpeg-dev \
+		mediainfo \
+		pipx \
+		python3 \
+		zlib1g-dev >/dev/null
+}
+
+install_fedora_dependencies() {
+	echo "正在安装Fedora依赖..."
+	local packages=(ca-certificates curl libicu mediainfo pipx python3)
+	if ! run_as_root dnf install -y "${packages[@]}" ffmpeg-free; then
+		run_as_root dnf install -y "${packages[@]}" ffmpeg
 	fi
 }
 
-do_install
+enable_rhel_builder_repo() {
+	if ! command_exists dnf; then
+		return
+	fi
+
+	run_as_root dnf install -y dnf-plugins-core >/dev/null || true
+	run_as_root dnf config-manager --set-enabled crb >/dev/null 2>&1 || \
+		run_as_root dnf config-manager --set-enabled powertools >/dev/null 2>&1 || \
+		true
+}
+
+install_rhel_like_dependencies() {
+	echo "正在安装RHEL/CentOS/Rocky/AlmaLinux依赖..."
+	local pkg_manager="dnf"
+	if ! command_exists dnf; then
+		pkg_manager="yum"
+	fi
+
+	local major="${DIST_VERSION_ID%%.*}"
+	run_as_root "$pkg_manager" install -y ca-certificates >/dev/null
+	if ! command_exists curl; then
+		run_as_root "$pkg_manager" install -y curl-minimal || run_as_root "$pkg_manager" install -y curl
+	fi
+	enable_rhel_builder_repo
+
+	if ! run_as_root "$pkg_manager" install -y epel-release; then
+		run_as_root "$pkg_manager" install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${major}.noarch.rpm"
+	fi
+
+	run_as_root "$pkg_manager" install -y "https://download1.rpmfusion.org/free/el/rpmfusion-free-release-${major}.noarch.rpm" || true
+	run_as_root "$pkg_manager" install -y \
+		ffmpeg \
+		gcc \
+		libicu \
+		libjpeg-devel \
+		mediainfo \
+		pipx \
+		python3 \
+		python3-devel \
+		zlib-devel
+}
+
+install_arch_dependencies() {
+	echo "正在安装Arch依赖..."
+	run_as_root pacman -Sy --noconfirm --needed \
+		ca-certificates \
+		curl \
+		ffmpeg \
+		icu \
+		mediainfo \
+		python \
+		python-pipx >/dev/null
+}
+
+install_macos_dependencies() {
+	echo "正在安装macOS依赖..."
+	if ! command_exists brew; then
+		echo "macOS一键安装需要先安装Homebrew: https://brew.sh/"
+		exit 1
+	fi
+
+	brew update
+	brew install ffmpeg mediainfo pipx
+}
+
+install_linux_dependencies() {
+	if ! load_os_release; then
+		echo "无法读取 /etc/os-release，暂不支持当前Linux发行版。"
+		exit 1
+	fi
+
+	echo "检测到系统: $DIST_PRETTY_NAME"
+	if is_distro_like debian || is_distro_like ubuntu; then
+		install_apt_dependencies
+	elif is_distro_like fedora && [ "$DIST_ID" = "fedora" ]; then
+		install_fedora_dependencies
+	elif is_distro_like rhel || is_distro_like centos || is_distro_like fedora; then
+		install_rhel_like_dependencies
+	elif is_distro_like arch; then
+		install_arch_dependencies
+	else
+		echo "系统版本 $DIST_PRETTY_NAME 还未支持！"
+		exit 1
+	fi
+}
+
+verify_install() {
+	if [ "$DIFFERENTIAL_SKIP_INSTALL" = "1" ]; then
+		echo "依赖安装检查已跳过差速器命令验证"
+		return
+	fi
+
+	add_pipx_bin_to_path
+	if command_exists dft; then
+		echo "差速器安装成功"
+	else
+		echo "差速器安装失败"
+		exit 1
+	fi
+}
+
+do_install() {
+	setup_sudo
+	case "$(uname -s)" in
+		Linux)
+			install_linux_dependencies
+			;;
+		Darwin)
+			install_macos_dependencies
+			;;
+		*)
+			echo "当前系统 $(uname -s) 还未支持！"
+			exit 1
+			;;
+	esac
+
+	install_bdinfo
+	install_differential
+	verify_install
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	do_install
+fi


### PR DESCRIPTION
## Summary

- Refactor `install.sh` around OS/package-manager capability instead of stale distro codename remapping.
- Support current Debian/Ubuntu apt, Fedora dnf, RHEL-like dnf/yum, Arch pacman, and macOS/Homebrew flows.
- Install native BDInfoCLI for Linux and macOS by selecting the correct `linux-*` or `osx-*` upstream release asset.
- Add ICU runtime dependencies required by native BDInfoCLI on Linux.
- Update README install guidance for modern Linux distros and macOS one-command installation.

## Validation

Local checks:

- `shellcheck install.sh` passed.
- `bash -n install.sh` passed.
- `/home/lei/workspace/created/Differential/.venv/bin/python -m unittest discover -s tests` passed: 34 tests.
- `/home/lei/workspace/created/Differential/.venv/bin/python -m compileall -q src/differential tests` passed.
- `git diff --check` passed.
- Helper checks confirmed BDInfo runtime selection for `osx-arm64`, `osx-x64`, and `linux-arm64`.

Docker checks:

- Full install on `debian:stable-slim` / Debian 13 trixie passed:
  - `BDInfo --version` -> `0.8.0.0`
  - `ffmpeg -version` available
  - `mediainfo --Version` available
  - pipx-installed `/root/.local/bin/dft` exists
- Dependency and BDInfo install matrix with `DIFFERENTIAL_SKIP_INSTALL=1` passed:
  - `debian:stable-slim` / Debian 13 trixie
  - `ubuntu:26.04` / Ubuntu 26.04 LTS
  - `fedora:latest` / Fedora 44 container image
  - `archlinux:latest`
  - `almalinux:9` / AlmaLinux 9.8

## Notes

The Docker runs caught two real installer gaps before this version: native BDInfoCLI needs ICU on Linux, and AlmaLinux 9 has `curl-minimal` preinstalled, which conflicts with installing the full `curl` package. Both are handled in this PR.
