### PR TITLE
Support macOS ISO auto-mounting

### DIFF
--- a/src/differential/utils/mediainfo_handler.py
+++ b/src/differential/utils/mediainfo_handler.py
@@ -16,7 +16,7 @@ from differential import tools
 from differential.version import version
 from differential.utils.binary import execute_with_output
 from differential.utils.mediainfo import get_full_mediainfo, get_duration, get_resolution
-from differential.utils.privilege import run_with_sudo_fallback
+from differential.utils.privilege import run_command, run_with_sudo_fallback
 
 
 BDINFO_ENV_VAR = "BDINFOPATH"
@@ -99,6 +99,7 @@ class MediaInfoHandler:
         self.main_file = None
         self.iso_mount_dir: Optional[Path] = None
         self.iso_mount_parent: Optional[Path] = None
+        self.iso_mount_platform: Optional[str] = None
 
     def find_mediainfo(self):
         """
@@ -140,7 +141,19 @@ class MediaInfoHandler:
         if not self.iso_mount_dir:
             return
 
-        if self._is_mountpoint(self.iso_mount_dir):
+        if self.iso_mount_platform == "Darwin":
+            detached = (
+                run_command(
+                    ["hdiutil", "detach", str(self.iso_mount_dir)],
+                    action=f"卸载ISO: {self.iso_mount_dir}",
+                    abort=False,
+                ).returncode
+                == 0
+            )
+            if not detached:
+                logger.warning(f"[ISO] 未能卸载挂载点，请手动检查: {self.iso_mount_dir}")
+                return
+        elif self._is_mountpoint(self.iso_mount_dir):
             run_with_sudo_fallback(
                 ["umount", "--", str(self.iso_mount_dir)],
                 action=f"卸载ISO: {self.iso_mount_dir}",
@@ -160,6 +173,7 @@ class MediaInfoHandler:
 
         self.iso_mount_dir = None
         self.iso_mount_parent = None
+        self.iso_mount_platform = None
 
     @staticmethod
     def _media_name(folder: Path) -> str:
@@ -184,7 +198,8 @@ class MediaInfoHandler:
         return False
 
     def _mount_iso(self) -> None:
-        if platform.system() != "Linux":
+        system = platform.system()
+        if system not in ("Linux", "Darwin"):
             logger.error("请先挂载ISO文件再使用。")
             sys.exit(1)
 
@@ -193,11 +208,27 @@ class MediaInfoHandler:
         self.iso_mount_dir.mkdir()
 
         logger.info(f"[ISO] 正在挂载ISO: {self.original_folder}")
-        run_with_sudo_fallback(
-            ["mount", "-o", "ro,loop", "--", str(self.original_folder.resolve()), str(self.iso_mount_dir)],
-            action=f"挂载ISO: {self.original_folder}",
-            abort=True,
-        )
+        if system == "Darwin":
+            run_command(
+                [
+                    "hdiutil",
+                    "attach",
+                    "-readonly",
+                    "-nobrowse",
+                    "-mountpoint",
+                    str(self.iso_mount_dir),
+                    str(self.original_folder.resolve()),
+                ],
+                action=f"挂载ISO: {self.original_folder}",
+                abort=True,
+            )
+        else:
+            run_with_sudo_fallback(
+                ["mount", "-o", "ro,loop", "--", str(self.original_folder.resolve()), str(self.iso_mount_dir)],
+                action=f"挂载ISO: {self.original_folder}",
+                abort=True,
+            )
+        self.iso_mount_platform = system
         self.folder = self.iso_mount_dir
         logger.info(f"[ISO] 已挂载到: {self.folder}")
 

--- a/src/differential/utils/privilege.py
+++ b/src/differential/utils/privilege.py
@@ -50,6 +50,15 @@ def _finish(action: str, proc: subprocess.CompletedProcess, abort: bool) -> subp
     return proc
 
 
+def run_command(
+    cmd: List[str],
+    *,
+    action: str,
+    abort: bool = True,
+) -> subprocess.CompletedProcess:
+    return _finish(action, _run(cmd, capture=True), abort)
+
+
 def run_with_sudo_fallback(
     cmd: List[str],
     *,

--- a/tests/test_iso_mount.py
+++ b/tests/test_iso_mount.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from differential.base_plugin import Base
 from differential.utils.mediainfo_handler import MediaInfoHandler
-from differential.utils.privilege import run_with_sudo_fallback
+from differential.utils.privilege import run_command, run_with_sudo_fallback
 from differential.version import version
 
 
@@ -21,6 +21,22 @@ def completed(cmd, returncode=0, stdout="", stderr=""):
 
 
 class PrivilegeHelperTest(unittest.TestCase):
+    def test_run_command_returns_direct_success(self):
+        with mock.patch("subprocess.run", return_value=completed(["hdiutil"])) as run:
+            proc = run_command(["hdiutil"], action="hdiutil test")
+
+        self.assertEqual(proc.returncode, 0)
+        run.assert_called_once_with(["hdiutil"], text=True, capture_output=True)
+
+    def test_run_command_returns_failure_without_abort(self):
+        with mock.patch(
+            "subprocess.run",
+            return_value=completed(["hdiutil"], returncode=1, stderr="detach failed"),
+        ):
+            proc = run_command(["hdiutil"], action="hdiutil test", abort=False)
+
+        self.assertEqual(proc.returncode, 1)
+
     def test_run_with_sudo_fallback_uses_direct_success(self):
         with mock.patch("subprocess.run", return_value=completed(["mount"])) as run:
             proc = run_with_sudo_fallback(["mount"], action="mount test")
@@ -158,7 +174,69 @@ class MediaInfoIsoMountTest(unittest.TestCase):
             )
             self.assertEqual(handler.folder, expected_mount_dir)
 
-    def test_mount_iso_exits_on_non_linux(self):
+    def test_mount_iso_uses_hdiutil_attach_on_macos(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            iso = root / "-leading-dash.iso"
+            iso.write_bytes(b"iso")
+            mount_parent = root / "mount-parent"
+            mount_parent.mkdir()
+            handler = MediaInfoHandler(iso, False, False, True)
+
+            with mock.patch(
+                "differential.utils.mediainfo_handler.platform.system",
+                return_value="Darwin",
+            ), mock.patch(
+                "differential.utils.mediainfo_handler.tempfile.mkdtemp",
+                return_value=str(mount_parent),
+            ), mock.patch(
+                "differential.utils.mediainfo_handler.run_command",
+                return_value=completed(["hdiutil"]),
+            ) as run:
+                handler._mount_iso()
+
+            expected_mount_dir = mount_parent / handler.cache_key
+            run.assert_called_once_with(
+                [
+                    "hdiutil",
+                    "attach",
+                    "-readonly",
+                    "-nobrowse",
+                    "-mountpoint",
+                    str(expected_mount_dir),
+                    str(iso.resolve()),
+                ],
+                action=f"挂载ISO: {iso}",
+                abort=True,
+            )
+            self.assertEqual(handler.folder, expected_mount_dir)
+            self.assertEqual(handler.iso_mount_platform, "Darwin")
+
+    def test_cleanup_detaches_macos_iso_and_removes_temp_mount_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp) / "iso-parent"
+            mount_dir = parent / "movie"
+            mount_dir.mkdir(parents=True)
+            handler = MediaInfoHandler(mount_dir / "movie.iso", False, False, True)
+            handler.iso_mount_parent = parent
+            handler.iso_mount_dir = mount_dir
+            handler.iso_mount_platform = "Darwin"
+
+            with mock.patch(
+                "differential.utils.mediainfo_handler.run_command",
+                return_value=completed(["hdiutil"]),
+            ) as run, mock.patch.object(handler, "_is_mountpoint", return_value=False):
+                handler.cleanup()
+
+            run.assert_called_once_with(
+                ["hdiutil", "detach", str(mount_dir)],
+                action=f"卸载ISO: {mount_dir}",
+                abort=False,
+            )
+            self.assertFalse(parent.exists())
+            self.assertIsNone(handler.iso_mount_platform)
+
+    def test_mount_iso_exits_on_unsupported_platform(self):
         with tempfile.TemporaryDirectory() as tmp:
             iso = Path(tmp) / "Movie.iso"
             iso.write_bytes(b"iso")
@@ -166,7 +244,7 @@ class MediaInfoIsoMountTest(unittest.TestCase):
 
             with mock.patch(
                 "differential.utils.mediainfo_handler.platform.system",
-                return_value="Darwin",
+                return_value="Windows",
             ), self.assertRaises(SystemExit):
                 handler._mount_iso()
 


### PR DESCRIPTION
## Summary

Adds macOS support to the ISO auto-mount workflow so `.iso` inputs can be mounted automatically before MediaInfo/BDInfo discovery.

- Mounts ISO files on macOS with `hdiutil attach -readonly -nobrowse -mountpoint ...`.
- Detaches macOS ISO mounts during `MediaInfoHandler.cleanup()` with `hdiutil detach ...`.
- Adds a small non-sudo command helper beside the sudo-aware Linux mount helper.
- Keeps BDInfo runner selection unchanged, so native BDInfo support and Mono fallback are not affected.

## Validation run on Linux

- `python -m unittest discover -s tests` -> 38 passed.
- `git diff --check` -> clean.
- Real ISO smoke with `/mnt/fnos/Downloads/7000077871.iso` mounted the ISO, found the BDMV stream, and cleaned the temp mount directory.

## Manual macOS test instructions

Use a Mac checkout of this branch and replace `/path/to/movie.iso` with a real ISO path.

```bash
git fetch origin macos-iso-auto-mount
git checkout macos-iso-auto-mount
python -m unittest discover -s tests
```

Mount/detach smoke test without running BDInfo:

```bash
PYTHONPATH=src python - <<'PY'
from pathlib import Path
from differential.utils.mediainfo_handler import MediaInfoHandler

iso = Path('/path/to/movie.iso')
handler = MediaInfoHandler(iso, create_folder=False, use_short_bdinfo=False, scan_bdinfo=False)
try:
    handler._mount_iso()
    print(f'MOUNTED={handler.folder}')
    print(f'BDMV_EXISTS={(handler.folder / "BDMV").exists()}')
    print('TOP_LEVEL=', [p.name for p in handler.folder.iterdir()][:20])
finally:
    handler.cleanup()
    print(f'CLEANED_MOUNT_DIR={handler.iso_mount_dir}')
PY
```

Expected result:

- `MOUNTED=` points to a temp directory under `/tmp/Differential.iso...`.
- For a Blu-ray ISO, `BDMV_EXISTS=True`.
- `CLEANED_MOUNT_DIR=None` after cleanup.
- `hdiutil info | grep Differential.iso` should show no remaining mount from this run.

Full Differential path smoke, still skipping BDInfo scan:

```bash
PYTHONPATH=src python - <<'PY'
from pathlib import Path
from differential.utils.mediainfo_handler import MediaInfoHandler

iso = Path('/path/to/movie.iso')
handler = MediaInfoHandler(iso, create_folder=False, use_short_bdinfo=False, scan_bdinfo=False)
try:
    main_file = handler.find_mediainfo()
    print(f'MAIN_FILE={main_file}')
    print(f'IS_BDMV={handler.is_bdmv}')
    print(f'BDINFO={handler.bdinfo}')
finally:
    handler.cleanup()
    print(f'CLEANED_MOUNT_DIR={handler.iso_mount_dir}')
PY
```

If you want to test BDInfo itself on macOS, set `scan_bdinfo=True` after confirming either a native `BDInfo`/`bdinfo` binary is on `PATH` or Mono is installed for the bundled `BDInfo.exe` fallback.
